### PR TITLE
refactor: move stubs to inertia/ directory

### DIFF
--- a/configure.ts
+++ b/configure.ts
@@ -185,7 +185,7 @@ export async function configure(command: Configure) {
   /**
    * Add Inertia middleware
    */
-  await codemods.registerMiddleware('router', [
+  await codemods.registerMiddleware('server', [
     { path: '@adonisjs/inertia/inertia_middleware', position: 'after' },
   ])
 

--- a/configure.ts
+++ b/configure.ts
@@ -205,6 +205,8 @@ export async function configure(command: Configure) {
   await codemods.makeUsingStub(stubsRoot, `${stubFolder}/tsconfig.json.stub`, {})
   await codemods.makeUsingStub(stubsRoot, `${stubFolder}/app.${appExt}.stub`, { ssr })
   await codemods.makeUsingStub(stubsRoot, `${stubFolder}/home.${compExt}.stub`, {})
+  await codemods.makeUsingStub(stubsRoot, `${stubFolder}/errors/not_found.${compExt}.stub`, {})
+  await codemods.makeUsingStub(stubsRoot, `${stubFolder}/errors/server_error.${compExt}.stub`, {})
 
   if (ssr) {
     await codemods.makeUsingStub(stubsRoot, `${stubFolder}/ssr.${appExt}.stub`, {})

--- a/configure.ts
+++ b/configure.ts
@@ -43,7 +43,7 @@ const ADAPTERS_INFO: {
       pluginCall: 'vue()',
       importDeclarations: [{ isNamed: false, module: '@vitejs/plugin-vue', identifier: 'vue' }],
     },
-    ssrEntrypoint: 'resources/ssr.ts',
+    ssrEntrypoint: 'inertia/app/ssr.ts',
   },
   react: {
     stubFolder: 'react',
@@ -61,7 +61,7 @@ const ADAPTERS_INFO: {
       pluginCall: 'react()',
       importDeclarations: [{ isNamed: false, module: '@vitejs/plugin-react', identifier: 'react' }],
     },
-    ssrEntrypoint: 'resources/ssr.tsx',
+    ssrEntrypoint: 'inertia/app/ssr.tsx',
   },
   svelte: {
     stubFolder: 'svelte',
@@ -79,7 +79,7 @@ const ADAPTERS_INFO: {
         { isNamed: true, module: '@sveltejs/vite-plugin-svelte', identifier: 'svelte' },
       ],
     },
-    ssrEntrypoint: 'resources/ssr.ts',
+    ssrEntrypoint: 'inertia/app/ssr.ts',
   },
   solid: {
     stubFolder: 'solid',
@@ -96,7 +96,7 @@ const ADAPTERS_INFO: {
       ssrPluginCall: 'solid({ ssr: true })',
       importDeclarations: [{ isNamed: false, module: 'vite-plugin-solid', identifier: 'solid' }],
     },
-    ssrEntrypoint: 'resources/ssr.tsx',
+    ssrEntrypoint: 'inertia/app/ssr.tsx',
   },
 }
 
@@ -214,7 +214,7 @@ export async function configure(command: Configure) {
    * Register the inertia plugin in vite config
    */
   const inertiaPluginCall = ssr
-    ? `inertia({ ssr: { enabled: true, entrypoint: 'resources/ssr.${appExt}' } })`
+    ? `inertia({ ssr: { enabled: true, entrypoint: 'inertia/app/ssr.${appExt}' } })`
     : `inertia({ ssr: { enabled: false } })`
 
   await codemods.registerVitePlugin(inertiaPluginCall, [
@@ -234,7 +234,7 @@ export async function configure(command: Configure) {
   /**
    * Register vite with adonisjs plugin
    */
-  const adonisjsPluginCall = `adonisjs({ entrypoints: ['resources/app.${appExt}'], reload: ['resources/views/**/*.edge'] })`
+  const adonisjsPluginCall = `adonisjs({ entrypoints: ['inertia/app/app.${appExt}'], reload: ['resources/views/**/*.edge'] })`
   await codemods.registerVitePlugin(adonisjsPluginCall, [
     { isNamed: false, module: '@adonisjs/vite/client', identifier: 'adonisjs' },
   ])

--- a/src/define_config.ts
+++ b/src/define_config.ts
@@ -28,12 +28,14 @@ export function defineConfig(config: InertiaConfig): ConfigProvider<ResolvedConf
       versionCache,
       rootView: config.rootView ?? 'root',
       sharedData: config.sharedData || {},
-      entrypoint: slash(config.entrypoint ?? (await detector.detectEntrypoint('resources/app.ts'))),
+      entrypoint: slash(
+        config.entrypoint ?? (await detector.detectEntrypoint('inertia/app/app.ts'))
+      ),
       ssr: {
         enabled: config.ssr?.enabled ?? false,
         pages: config.ssr?.pages,
         entrypoint:
-          config.ssr?.entrypoint ?? (await detector.detectSsrEntrypoint('resources/ssr.ts')),
+          config.ssr?.entrypoint ?? (await detector.detectSsrEntrypoint('inertia/app/ssr.ts')),
 
         bundle: config.ssr?.bundle ?? (await detector.detectSsrBundle('ssr/ssr.js')),
       },

--- a/src/define_config.ts
+++ b/src/define_config.ts
@@ -26,7 +26,7 @@ export function defineConfig(config: InertiaConfig): ConfigProvider<ResolvedConf
 
     return {
       versionCache,
-      rootView: config.rootView ?? 'root',
+      rootView: config.rootView ?? 'inertia_layout',
       sharedData: config.sharedData || {},
       entrypoint: slash(
         config.entrypoint ?? (await detector.detectEntrypoint('inertia/app/app.ts'))

--- a/src/files_detector.ts
+++ b/src/files_detector.ts
@@ -19,14 +19,13 @@ export class FilesDetector {
    */
   async detectEntrypoint(defaultPath: string) {
     const possiblesLocations = [
+      './inertia/app/app.ts',
+      './inertia/app/app.tsx',
       './resources/app.ts',
       './resources/app.tsx',
-      './resources/application/app.ts',
-      './resources/application/app.tsx',
       './resources/app.jsx',
       './resources/app.js',
-      './resources/application/app.jsx',
-      './resources/application/app.js',
+      './inertia/app/app.jsx',
     ]
 
     const path = await locatePath(possiblesLocations, { cwd: this.app.appRoot })
@@ -39,14 +38,13 @@ export class FilesDetector {
    */
   async detectSsrEntrypoint(defaultPath: string) {
     const possiblesLocations = [
+      './inertia/app/ssr.ts',
+      './inertia/app/ssr.tsx',
       './resources/ssr.ts',
       './resources/ssr.tsx',
-      './resources/application/ssr.ts',
-      './resources/application/ssr.tsx',
       './resources/ssr.jsx',
       './resources/ssr.js',
-      './resources/application/ssr.jsx',
-      './resources/application/ssr.js',
+      './inertia/app/ssr.jsx',
     ]
 
     const path = await locatePath(possiblesLocations, { cwd: this.app.appRoot })

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export type AssetsVersion = string | number | undefined
 export interface InertiaConfig {
   /**
    * Path to the Edge view that will be used as the root view for Inertia responses.
-   * @default root (resources/views/root.edge)
+   * @default root (resources/views/inertia_layout.edge)
    */
   rootView?: string
 

--- a/stubs/app.css.stub
+++ b/stubs/app.css.stub
@@ -1,5 +1,5 @@
 {{{
-  exports({ to: app.makePath('resources/css/app.css') })
+  exports({ to: app.makePath('inertia/css/app.css') })
 }}}
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500&display=swap');
 

--- a/stubs/config.stub
+++ b/stubs/config.stub
@@ -13,7 +13,7 @@ export default defineConfig({
    * Data that should be shared with all rendered pages
    */
   sharedData: {
-    errors: (ctx) => ctx.session.flashMessages.get('errors'),
+    errors: (ctx) => ctx.session?.flashMessages.get('errors'),
   },
 
   /**

--- a/stubs/config.stub
+++ b/stubs/config.stub
@@ -7,7 +7,7 @@ export default defineConfig({
   /**
    * Path to the Edge view that will be used as the root view for Inertia responses
    */
-  rootView: 'root',
+  rootView: 'inertia_layout',
 
   /**
    * Data that should be shared with all rendered pages

--- a/stubs/react/app.tsx.stub
+++ b/stubs/react/app.tsx.stub
@@ -1,7 +1,7 @@
 {{{
-  exports({ to: app.makePath('resources/app.tsx') })
+  exports({ to: app.makePath('inertia/app/app.tsx') })
 }}}
-import './css/app.css';
+import '../css/app.css';
 
 {{#if ssr}}
 import { hydrateRoot } from 'react-dom/client'
@@ -20,8 +20,8 @@ createInertiaApp({
 
   resolve: (name) => {
     return resolvePageComponent(
-      {{ '`./pages/${name}.tsx`' }},
-      import.meta.glob('./pages/**/*.tsx'),
+      {{ '`../pages/${name}.tsx`' }},
+      import.meta.glob('../pages/**/*.tsx'),
     )
   },
 

--- a/stubs/react/errors/not_found.tsx.stub
+++ b/stubs/react/errors/not_found.tsx.stub
@@ -1,0 +1,14 @@
+{{{
+  exports({ to: app.makePath('inertia/pages/errors/not_found.tsx') })
+}}}
+export default function NotFound() {
+  return (
+    <>
+      <div className="container">
+        <div className="title">Page not found</div>
+
+        <span>This page does not exist.</span>
+      </div>
+    </>
+  )
+}

--- a/stubs/react/errors/server_error.tsx.stub
+++ b/stubs/react/errors/server_error.tsx.stub
@@ -1,0 +1,14 @@
+{{{
+  exports({ to: app.makePath('inertia/pages/errors/server_error.tsx') })
+}}}
+export default function ServerError(props: { error: any }) {
+  return (
+    <>
+      <div className="container">
+        <div className="title">Server Error</div>
+
+        <span>{props.error.message}</span>
+      </div>
+    </>
+  )
+}

--- a/stubs/react/home.tsx.stub
+++ b/stubs/react/home.tsx.stub
@@ -1,5 +1,5 @@
 {{{
-  exports({ to: app.makePath('resources/pages/home.tsx') })
+  exports({ to: app.makePath('inertia/pages/home.tsx') })
 }}}
 import { Head } from '@inertiajs/react'
 

--- a/stubs/react/root.edge.stub
+++ b/stubs/react/root.edge.stub
@@ -1,5 +1,5 @@
 {{{
-  exports({ to: app.makePath('resources/views/root.edge') })
+  exports({ to: app.makePath('resources/views/inertia_layout.edge') })
 }}}
 <!DOCTYPE html>
 <html>

--- a/stubs/react/root.edge.stub
+++ b/stubs/react/root.edge.stub
@@ -12,7 +12,7 @@
 
   @viteReactRefresh()
   @inertiaHead()
-  {{ "@vite(['resources/app.tsx', `resources/pages/${page.component}.tsx`])" }}
+  {{ "@vite(['inertia/app/app.tsx', `inertia/pages/${page.component}.tsx`])" }}
 </head>
 
 <body>

--- a/stubs/react/ssr.tsx.stub
+++ b/stubs/react/ssr.tsx.stub
@@ -1,5 +1,5 @@
 {{{
-  exports({ to: app.makePath('resources/ssr.tsx') })
+  exports({ to: app.makePath('inertia/app/ssr.tsx') })
 }}}
 import ReactDOMServer from 'react-dom/server'
 import { createInertiaApp } from '@inertiajs/react'
@@ -9,8 +9,8 @@ export default function render(page: any) {
     page,
     render: ReactDOMServer.renderToString,
     resolve: (name) => {
-      const pages = import.meta.glob('./pages/**/*.tsx', { eager: true })
-      {{ 'return pages[`./pages/${name}.tsx`]' }}
+      const pages = import.meta.glob('../pages/**/*.tsx', { eager: true })
+      {{ 'return pages[`../pages/${name}.tsx`]' }}
     },
     setup: ({ App, props }) => <App {...props} />,
   })

--- a/stubs/react/tsconfig.json.stub
+++ b/stubs/react/tsconfig.json.stub
@@ -1,25 +1,15 @@
 {{{
-  exports({ to: app.makePath('resources/tsconfig.json') })
+  exports({ to: app.makePath('inertia/tsconfig.json') })
 }}}
 {
+  "extends": "@adonisjs/tsconfig/tsconfig.client.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "jsx": "react-jsx",
-    "lib": ["DOM", "ESNext", "DOM.Iterable", "ES2020"],
-    "useDefineForClassFields": true,
     "baseUrl": ".",
     "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
     "paths": {
-      "@/*": ["./*"],
       "~/*": ["../*"],
     },
-    "resolveJsonModule": true,
-    "types": ["vite/client"],
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "verbatimModuleSyntax": true,
-    "skipLibCheck": true,
   },
   "include": ["./**/*.ts", "./**/*.tsx"],
 }

--- a/stubs/solid/app.tsx.stub
+++ b/stubs/solid/app.tsx.stub
@@ -1,7 +1,7 @@
 {{{
-  exports({ to: app.makePath('resources/app.tsx') })
+  exports({ to: app.makePath('inertia/app/app.tsx') })
 }}}
-import './css/app.css'
+import '../css/app.css'
 
 {{#if ssr}}
 import { hydrate } from 'solid-js/web';
@@ -20,8 +20,8 @@ createInertiaApp({
 
   resolve: (name) => {
     return resolvePageComponent(
-      {{ '`./pages/${name}.tsx`' }},
-      import.meta.glob('./pages/**/*.tsx'),
+      {{ '`../pages/${name}.tsx`' }},
+      import.meta.glob('../pages/**/*.tsx'),
     )
   },
 

--- a/stubs/solid/errors/not_found.tsx.stub
+++ b/stubs/solid/errors/not_found.tsx.stub
@@ -1,0 +1,14 @@
+{{{
+  exports({ to: app.makePath('inertia/pages/errors/not_found.tsx') })
+}}}
+export default function NotFound() {
+  return (
+    <>
+      <div class="container">
+        <div class="title">Page not found</div>
+
+        <span>This page does not exist.</span>
+      </div>
+    </>
+  )
+}

--- a/stubs/solid/errors/server_error.tsx.stub
+++ b/stubs/solid/errors/server_error.tsx.stub
@@ -1,0 +1,14 @@
+{{{
+  exports({ to: app.makePath('inertia/pages/errors/server_error.tsx') })
+}}}
+export default function ServerError(props: { error: any }) {
+  return (
+    <>
+      <div class="container">
+        <div class="title">Server Error</div>
+
+        <span>{props.error.message}</span>
+      </div>
+    </>
+  )
+}

--- a/stubs/solid/home.tsx.stub
+++ b/stubs/solid/home.tsx.stub
@@ -1,13 +1,10 @@
 {{{
-  exports({ to: app.makePath('resources/pages/home.tsx') })
+  exports({ to: app.makePath('inertia/pages/home.tsx') })
 }}}
-import { Title } from '@solidjs/meta'
 
 export default function Home(props: { version: number }) {
   return (
     <>
-      <Title>Homepage</Title>
-
       <div class="container">
         <div class="title">AdonisJS {props.version} x Inertia x Solid.js</div>
 

--- a/stubs/solid/root.edge.stub
+++ b/stubs/solid/root.edge.stub
@@ -1,5 +1,5 @@
 {{{
-  exports({ to: app.makePath('resources/views/root.edge') })
+  exports({ to: app.makePath('resources/views/inertia_layout.edge') })
 }}}
 <!DOCTYPE html>
 <html>

--- a/stubs/solid/root.edge.stub
+++ b/stubs/solid/root.edge.stub
@@ -11,7 +11,7 @@
   <title inertia>AdonisJS x Inertia x SolidJS</title>
 
   @inertiaHead()
-  {{ "@vite(['resources/app.tsx', `resources/pages/${page.component}.tsx`])" }}
+  {{ "@vite(['inertia/app/app.tsx', `inertia/pages/${page.component}.tsx`])" }}
 </head>
 
 <body>

--- a/stubs/solid/ssr.tsx.stub
+++ b/stubs/solid/ssr.tsx.stub
@@ -1,5 +1,5 @@
 {{{
-  exports({ to: app.makePath('resources/ssr.tsx') })
+  exports({ to: app.makePath('inertia/app/ssr.tsx') })
 }}}
 
 import { hydrate } from 'solid-js/web'
@@ -9,8 +9,8 @@ export default function render(page: any) {
   return createInertiaApp({
     page,
     resolve: (name) => {
-      const pages = import.meta.glob('./pages/**/*.tsx', { eager: true })
-      {{ 'return pages[`./pages/${name}.tsx`]' }}
+      const pages = import.meta.glob('../pages/**/*.tsx', { eager: true })
+      {{ 'return pages[`../pages/${name}.tsx`]' }}
     },
     setup({ el, App, props }) {
       hydrate(() => <App {...props} />, el)

--- a/stubs/solid/tsconfig.json.stub
+++ b/stubs/solid/tsconfig.json.stub
@@ -1,26 +1,16 @@
 {{{
-  exports({ to: app.makePath('resources/tsconfig.json') })
+  exports({ to: app.makePath('inertia/tsconfig.json') })
 }}}
 {
+  "extends": "@adonisjs/tsconfig/tsconfig.client.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "jsx": "preserve",
-    "jsxImportSource": "solid-js",
-    "lib": ["DOM", "ESNext", "DOM.Iterable", "ES2020"],
-    "useDefineForClassFields": true,
     "baseUrl": ".",
+    "jsx": "preserve",
     "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "jsxImportSource": "solid-js",
     "paths": {
-      "@/*": ["./*"],
-      "~/*": ["../*"],
+      "~/*": ["./*"],
     },
-    "resolveJsonModule": true,
-    "types": ["vite/client"],
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "verbatimModuleSyntax": true,
-    "skipLibCheck": true,
   },
   "include": ["./**/*.ts", "./**/*.tsx"],
 }

--- a/stubs/svelte/app.ts.stub
+++ b/stubs/svelte/app.ts.stub
@@ -1,7 +1,7 @@
 {{{
-  exports({ to: app.makePath('resources/app.ts') })
+  exports({ to: app.makePath('inertia/app/app.ts') })
 }}}
-import './css/app.css';
+import '../css/app.css';
 
 import { createInertiaApp } from '@inertiajs/svelte'
 import { resolvePageComponent } from '@adonisjs/inertia/helpers'
@@ -15,8 +15,8 @@ createInertiaApp({
 
   resolve: (name) => {
     return resolvePageComponent(
-      {{ '`./pages/${name}.svelte`' }},
-      import.meta.glob('./pages/**/*.svelte'),
+      {{ '`../pages/${name}.svelte`' }},
+      import.meta.glob('../pages/**/*.svelte'),
     )
   },
 

--- a/stubs/svelte/errors/not_found.svelte.stub
+++ b/stubs/svelte/errors/not_found.svelte.stub
@@ -1,0 +1,10 @@
+{{{
+  exports({ to: app.makePath('inertia/pages/errors/not_found.svelte') })
+}}}
+<div>
+  <div class="container">
+    <div class="title">Page not found</div>
+
+    <span>This page does not exist.</span>
+  </div>
+</div>

--- a/stubs/svelte/errors/server_error.svelte.stub
+++ b/stubs/svelte/errors/server_error.svelte.stub
@@ -1,0 +1,14 @@
+{{{
+  exports({ to: app.makePath('inertia/pages/errors/server_error.svelte') })
+}}}
+<script>
+export let error
+</script>
+
+<div>
+  <div class="container">
+    <div class="title">Server Error</div>
+
+    <span>{error.message}</span>
+  </div>
+</div>

--- a/stubs/svelte/home.svelte.stub
+++ b/stubs/svelte/home.svelte.stub
@@ -1,5 +1,5 @@
 {{{
-  exports({ to: app.makePath('resources/pages/home.svelte') })
+  exports({ to: app.makePath('inertia/pages/home.svelte') })
 }}}
 <script>
 export let version

--- a/stubs/svelte/root.edge.stub
+++ b/stubs/svelte/root.edge.stub
@@ -1,5 +1,5 @@
 {{{
-  exports({ to: app.makePath('resources/views/root.edge') })
+  exports({ to: app.makePath('resources/views/inertia_layout.edge') })
 }}}
 <!DOCTYPE html>
 <html>

--- a/stubs/svelte/root.edge.stub
+++ b/stubs/svelte/root.edge.stub
@@ -10,7 +10,7 @@
 
   <title inertia>AdonisJS x Inertia x Svelte</title>
 
-  {{ "@vite(['resources/app.ts', `resources/pages/${page.component}.svelte`])" }}
+  {{ "@vite(['inertia/app/app.ts', `inertia/pages/${page.component}.svelte`])" }}
   @inertiaHead()
 </head>
 

--- a/stubs/svelte/ssr.ts.stub
+++ b/stubs/svelte/ssr.ts.stub
@@ -1,5 +1,5 @@
 {{{
-  exports({ to: app.makePath('resources/ssr.ts') })
+  exports({ to: app.makePath('inertia/app/ssr.ts') })
 }}}
 
 import { createInertiaApp } from '@inertiajs/svelte'
@@ -8,8 +8,8 @@ export default function render(page: any) {
   return createInertiaApp({
     page,
     resolve: (name) => {
-      const pages = import.meta.glob('./pages/**/*.svelte', { eager: true })
-      {{ 'return pages[`./pages/${name}.svelte`]' }}
+      const pages = import.meta.glob('../pages/**/*.svelte', { eager: true })
+      {{ 'return pages[`../pages/${name}.svelte`]' }}
     }
   })
 }

--- a/stubs/svelte/tsconfig.json.stub
+++ b/stubs/svelte/tsconfig.json.stub
@@ -1,26 +1,14 @@
 {{{
-  exports({ to: app.makePath('resources/tsconfig.json') })
+  exports({ to: app.makePath('inertia/tsconfig.json') })
 }}}
 {
+  "extends": "@adonisjs/tsconfig/tsconfig.client.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "jsx": "preserve",
-    "jsxImportSource": "vue",
-    "lib": ["DOM", "ESNext", "DOM.Iterable", "ES2020"],
-    "useDefineForClassFields": true,
     "baseUrl": ".",
     "module": "ESNext",
-    "moduleResolution": "Bundler",
     "paths": {
-      "@/*": ["./*"],
-      "~/*": ["../*"],
+      "~/*": ["./*"],
     },
-    "resolveJsonModule": true,
-    "types": ["vite/client"],
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "verbatimModuleSyntax": true,
-    "skipLibCheck": true,
   },
   "include": ["./**/*.ts", "./**/*.svelte"],
 }

--- a/stubs/vue/app.ts.stub
+++ b/stubs/vue/app.ts.stub
@@ -1,7 +1,7 @@
 {{{
-  exports({ to: app.makePath('resources/app.ts') })
+  exports({ to: app.makePath('inertia/app/app.ts') })
 }}}
-import './css/app.css';
+import '../css/app.css';
 
 {{#if ssr}}
 import { createSSRApp, h } from 'vue'
@@ -21,8 +21,8 @@ createInertiaApp({
 
   resolve: (name) => {
     return resolvePageComponent(
-      {{ '`./pages/${name}.vue`' }},
-      import.meta.glob<DefineComponent>('./pages/**/*.vue'),
+      {{ '`../pages/${name}.vue`' }},
+      import.meta.glob<DefineComponent>('../pages/**/*.vue'),
     )
   },
 

--- a/stubs/vue/errors/not_found.vue.stub
+++ b/stubs/vue/errors/not_found.vue.stub
@@ -1,0 +1,10 @@
+{{{
+  exports({ to: app.makePath('inertia/pages/errors/not_found.vue') })
+}}}
+<template>
+  <div class="container">
+    <div class="title">Page not found</div>
+
+    <span>This page does not exist.</span>
+  </div>
+</template>

--- a/stubs/vue/errors/server_error.vue.stub
+++ b/stubs/vue/errors/server_error.vue.stub
@@ -1,0 +1,14 @@
+{{{
+  exports({ to: app.makePath('inertia/pages/errors/server_error.vue') })
+}}}
+<script setup lang="ts">
+defineProps<{ error: any }>();
+</script>
+
+<template>
+  <div class="container">
+    <div class="title">Server Error</div>
+
+    <span>\{\{ error.message \}\}</span>
+  </div>
+</template>

--- a/stubs/vue/home.vue.stub
+++ b/stubs/vue/home.vue.stub
@@ -1,5 +1,5 @@
 {{{
-  exports({ to: app.makePath('resources/pages/home.vue') })
+  exports({ to: app.makePath('inertia/pages/home.vue') })
 }}}
 <script setup lang="ts">
 import { Head } from '@inertiajs/vue3'

--- a/stubs/vue/root.edge.stub
+++ b/stubs/vue/root.edge.stub
@@ -1,5 +1,5 @@
 {{{
-  exports({ to: app.makePath('resources/views/root.edge') })
+  exports({ to: app.makePath('resources/views/inertia_layout.edge') })
 }}}
 <!DOCTYPE html>
 <html>

--- a/stubs/vue/root.edge.stub
+++ b/stubs/vue/root.edge.stub
@@ -10,7 +10,7 @@
 
   <title inertia>AdonisJS x Inertia x VueJS</title>
 
-  {{ "@vite(['resources/app.ts', `resources/pages/${page.component}.vue`])" }}
+  {{ "@vite(['inertia/app.ts', `inertia/pages/${page.component}.vue`])" }}
   @inertiaHead()
 </head>
 

--- a/stubs/vue/root.edge.stub
+++ b/stubs/vue/root.edge.stub
@@ -10,7 +10,7 @@
 
   <title inertia>AdonisJS x Inertia x VueJS</title>
 
-  {{ "@vite(['inertia/app.ts', `inertia/pages/${page.component}.vue`])" }}
+  {{ "@vite(['inertia/app/app.ts', `inertia/pages/${page.component}.vue`])" }}
   @inertiaHead()
 </head>
 

--- a/stubs/vue/ssr.ts.stub
+++ b/stubs/vue/ssr.ts.stub
@@ -1,5 +1,5 @@
 {{{
-  exports({ to: app.makePath('resources/ssr.ts') })
+  exports({ to: app.makePath('inertia/app/ssr.ts') })
 }}}
 
 import { createInertiaApp } from '@inertiajs/vue3'
@@ -11,8 +11,8 @@ export default function render(page: any) {
     page,
     render: renderToString,
     resolve: (name) => {
-      const pages = import.meta.glob<DefineComponent>('./pages/**/*.vue', { eager: true })
-      {{ 'return pages[`./pages/${name}.vue`]' }}
+      const pages = import.meta.glob<DefineComponent>('../pages/**/*.vue', { eager: true })
+      {{ 'return pages[`../pages/${name}.vue`]' }}
     },
 
     setup({ App, props, plugin }) {

--- a/stubs/vue/tsconfig.json.stub
+++ b/stubs/vue/tsconfig.json.stub
@@ -1,26 +1,16 @@
 {{{
-  exports({ to: app.makePath('resources/tsconfig.json') })
+  exports({ to: app.makePath('inertia/tsconfig.json') })
 }}}
 {
+  "extends": "@adonisjs/tsconfig/tsconfig.client.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "jsx": "preserve",
-    "jsxImportSource": "vue",
-    "lib": ["DOM", "ESNext", "DOM.Iterable", "ES2020"],
-    "useDefineForClassFields": true,
     "baseUrl": ".",
+    "jsx": "preserve",
     "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "jsxImportSource": "vue",
     "paths": {
-      "@/*": ["./*"],
-      "~/*": ["../*"],
+      "~/*": ["./*"],
     },
-    "resolveJsonModule": true,
-    "types": ["vite/client"],
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "verbatimModuleSyntax": true,
-    "skipLibCheck": true,
   },
   "include": ["./**/*.ts", "./**/*.vue"],
 }

--- a/tests/configure.spec.ts
+++ b/tests/configure.spec.ts
@@ -110,7 +110,7 @@ test.group('Frameworks', (group) => {
     await command.exec()
 
     await assert.fileExists('inertia/app/app.ts')
-    await assert.fileExists('resources/views/root.edge')
+    await assert.fileExists('resources/views/inertia_layout.edge')
     await assert.fileExists('inertia/tsconfig.json')
     await assert.fileExists('inertia/pages/home.vue')
     await assert.fileExists('inertia/pages/errors/not_found.vue')
@@ -139,7 +139,7 @@ test.group('Frameworks', (group) => {
     await command.exec()
 
     await assert.fileExists('inertia/app/app.tsx')
-    await assert.fileExists('resources/views/root.edge')
+    await assert.fileExists('resources/views/inertia_layout.edge')
     await assert.fileExists('inertia/tsconfig.json')
     await assert.fileExists('inertia/pages/home.tsx')
     await assert.fileExists('inertia/pages/errors/not_found.tsx')
@@ -168,7 +168,7 @@ test.group('Frameworks', (group) => {
     await command.exec()
 
     await assert.fileExists('inertia/app/app.tsx')
-    await assert.fileExists('resources/views/root.edge')
+    await assert.fileExists('resources/views/inertia_layout.edge')
     await assert.fileExists('inertia/tsconfig.json')
     await assert.fileExists('inertia/pages/home.tsx')
     await assert.fileExists('inertia/pages/errors/not_found.tsx')
@@ -197,7 +197,7 @@ test.group('Frameworks', (group) => {
     await command.exec()
 
     await assert.fileExists('inertia/app/app.ts')
-    await assert.fileExists('resources/views/root.edge')
+    await assert.fileExists('resources/views/inertia_layout.edge')
     await assert.fileExists('inertia/tsconfig.json')
     await assert.fileExists('inertia/pages/home.svelte')
     await assert.fileExists('inertia/pages/errors/not_found.svelte')
@@ -243,7 +243,7 @@ test.group('Frameworks | SSR', (group) => {
         /**
          * Path to the Edge view that will be used as the root view for Inertia responses
          */
-        rootView: 'root',
+        rootView: 'inertia_layout',
 
         /**
          * Data that should be shared with all rendered pages
@@ -289,7 +289,7 @@ test.group('Frameworks | SSR', (group) => {
         /**
          * Path to the Edge view that will be used as the root view for Inertia responses
          */
-        rootView: 'root',
+        rootView: 'inertia_layout',
 
         /**
          * Data that should be shared with all rendered pages
@@ -335,7 +335,7 @@ test.group('Frameworks | SSR', (group) => {
         /**
          * Path to the Edge view that will be used as the root view for Inertia responses
          */
-        rootView: 'root',
+        rootView: 'inertia_layout',
 
         /**
          * Data that should be shared with all rendered pages
@@ -366,7 +366,7 @@ test.group('Frameworks | SSR', (group) => {
     await command.exec()
 
     await assert.fileExists('inertia/app/app.ts')
-    await assert.fileExists('resources/views/root.edge')
+    await assert.fileExists('resources/views/inertia_layout.edge')
     await assert.fileExists('inertia/tsconfig.json')
     await assert.fileExists('inertia/pages/home.svelte')
     await assert.fileContains('inertia/app/app.ts', 'hydrate')

--- a/tests/configure.spec.ts
+++ b/tests/configure.spec.ts
@@ -110,11 +110,11 @@ test.group('Frameworks', (group) => {
     const command = await ace.create(Configure, ['../../index.js'])
     await command.exec()
 
-    await assert.fileExists('resources/app.ts')
+    await assert.fileExists('inertia/app/app.ts')
     await assert.fileExists('resources/views/root.edge')
-    await assert.fileExists('resources/tsconfig.json')
-    await assert.fileExists('resources/pages/home.vue')
-    await assert.fileContains('resources/app.ts', 'createApp')
+    await assert.fileExists('inertia/tsconfig.json')
+    await assert.fileExists('inertia/pages/home.vue')
+    await assert.fileContains('inertia/app/app.ts', 'createApp')
 
     const viteConfig = await fs.contents('vite.config.ts')
     assert.snapshot(viteConfig).matchInline(`
@@ -122,7 +122,7 @@ test.group('Frameworks', (group) => {
       import vue from '@vitejs/plugin-vue'
       import adonisjs from '@adonisjs/vite/client'
 
-      export default { plugins: [inertia({ ssr: { enabled: false } }), vue(), adonisjs({ entrypoints: ['resources/app.ts'], reload: ['resources/views/**/*.edge'] })] }
+      export default { plugins: [inertia({ ssr: { enabled: false } }), vue(), adonisjs({ entrypoints: ['inertia/app/app.ts'], reload: ['resources/views/**/*.edge'] })] }
       "
     `)
   })
@@ -137,11 +137,11 @@ test.group('Frameworks', (group) => {
     const command = await ace.create(Configure, ['../../index.js'])
     await command.exec()
 
-    await assert.fileExists('resources/app.tsx')
+    await assert.fileExists('inertia/app/app.tsx')
     await assert.fileExists('resources/views/root.edge')
-    await assert.fileExists('resources/tsconfig.json')
-    await assert.fileExists('resources/pages/home.tsx')
-    await assert.fileContains('resources/app.tsx', 'createRoot')
+    await assert.fileExists('inertia/tsconfig.json')
+    await assert.fileExists('inertia/pages/home.tsx')
+    await assert.fileContains('inertia/app/app.tsx', 'createRoot')
 
     const viteConfig = await fs.contents('vite.config.ts')
     assert.snapshot(viteConfig).matchInline(`
@@ -149,7 +149,7 @@ test.group('Frameworks', (group) => {
       import react from '@vitejs/plugin-react'
       import adonisjs from '@adonisjs/vite/client'
 
-      export default { plugins: [inertia({ ssr: { enabled: false } }), react(), adonisjs({ entrypoints: ['resources/app.tsx'], reload: ['resources/views/**/*.edge'] })] }
+      export default { plugins: [inertia({ ssr: { enabled: false } }), react(), adonisjs({ entrypoints: ['inertia/app/app.tsx'], reload: ['resources/views/**/*.edge'] })] }
       "
     `)
   })
@@ -164,11 +164,11 @@ test.group('Frameworks', (group) => {
     const command = await ace.create(Configure, ['../../index.js'])
     await command.exec()
 
-    await assert.fileExists('resources/app.tsx')
+    await assert.fileExists('inertia/app/app.tsx')
     await assert.fileExists('resources/views/root.edge')
-    await assert.fileExists('resources/tsconfig.json')
-    await assert.fileExists('resources/pages/home.tsx')
-    await assert.fileNotContains('resources/app.tsx', 'hydrateRoot')
+    await assert.fileExists('inertia/tsconfig.json')
+    await assert.fileExists('inertia/pages/home.tsx')
+    await assert.fileNotContains('inertia/app/app.tsx', 'hydrateRoot')
 
     const viteConfig = await fs.contents('vite.config.ts')
     assert.snapshot(viteConfig).matchInline(`
@@ -176,7 +176,7 @@ test.group('Frameworks', (group) => {
       import solid from 'vite-plugin-solid'
       import adonisjs from '@adonisjs/vite/client'
 
-      export default { plugins: [inertia({ ssr: { enabled: false } }), solid(), adonisjs({ entrypoints: ['resources/app.tsx'], reload: ['resources/views/**/*.edge'] })] }
+      export default { plugins: [inertia({ ssr: { enabled: false } }), solid(), adonisjs({ entrypoints: ['inertia/app/app.tsx'], reload: ['resources/views/**/*.edge'] })] }
       "
     `)
   })
@@ -191,11 +191,11 @@ test.group('Frameworks', (group) => {
     const command = await ace.create(Configure, ['../../index.js'])
     await command.exec()
 
-    await assert.fileExists('resources/app.ts')
+    await assert.fileExists('inertia/app/app.ts')
     await assert.fileExists('resources/views/root.edge')
-    await assert.fileExists('resources/tsconfig.json')
-    await assert.fileExists('resources/pages/home.svelte')
-    await assert.fileNotContains('resources/app.ts', 'hydrate')
+    await assert.fileExists('inertia/tsconfig.json')
+    await assert.fileExists('inertia/pages/home.svelte')
+    await assert.fileNotContains('inertia/app/app.ts', 'hydrate')
 
     const viteConfig = await fs.contents('vite.config.ts')
     assert.snapshot(viteConfig).matchInline(`
@@ -203,7 +203,7 @@ test.group('Frameworks', (group) => {
       import { svelte } from '@sveltejs/vite-plugin-svelte'
       import adonisjs from '@adonisjs/vite/client'
 
-      export default { plugins: [inertia({ ssr: { enabled: false } }), svelte(), adonisjs({ entrypoints: ['resources/app.ts'], reload: ['resources/views/**/*.edge'] })] }
+      export default { plugins: [inertia({ ssr: { enabled: false } }), svelte(), adonisjs({ entrypoints: ['inertia/app/app.ts'], reload: ['resources/views/**/*.edge'] })] }
       "
     `)
   })
@@ -226,7 +226,7 @@ test.group('Frameworks | SSR', (group) => {
     const command = await ace.create(Configure, ['../../index.js'])
     await command.exec()
 
-    await assert.fileExists('resources/ssr.ts')
+    await assert.fileExists('inertia/app/ssr.ts')
     await assert.fileContains('vite.config.ts', 'inertia({ ssr: { enabled: true')
     const inertiaConfig = await fs.contents('config/inertia.ts')
     assert.snapshot(inertiaConfig).matchInline(`
@@ -242,7 +242,7 @@ test.group('Frameworks | SSR', (group) => {
          * Data that should be shared with all rendered pages
          */
         sharedData: {
-          errors: (ctx) => ctx.session.flashMessages.get('errors'),
+          errors: (ctx) => ctx.session?.flashMessages.get('errors'),
         },
 
         /**
@@ -250,7 +250,7 @@ test.group('Frameworks | SSR', (group) => {
          */
         ssr: {
           enabled: true,
-          entrypoint: 'resources/ssr.ts'
+          entrypoint: 'inertia/app/ssr.ts'
         }
       })"
     `)
@@ -266,12 +266,12 @@ test.group('Frameworks | SSR', (group) => {
     const command = await ace.create(Configure, ['../../index.js'])
     await command.exec()
 
-    await assert.fileExists('resources/app.tsx')
+    await assert.fileExists('inertia/app/app.tsx')
     await assert.fileContains(
       'vite.config.ts',
-      `inertia({ ssr: { enabled: true, entrypoint: 'resources/ssr.tsx' } })`
+      `inertia({ ssr: { enabled: true, entrypoint: 'inertia/app/ssr.tsx' } })`
     )
-    await assert.fileContains('resources/app.tsx', 'hydrateRoot')
+    await assert.fileContains('inertia/app/app.tsx', 'hydrateRoot')
 
     const inertiaConfig = await fs.contents('config/inertia.ts')
 
@@ -288,7 +288,7 @@ test.group('Frameworks | SSR', (group) => {
          * Data that should be shared with all rendered pages
          */
         sharedData: {
-          errors: (ctx) => ctx.session.flashMessages.get('errors'),
+          errors: (ctx) => ctx.session?.flashMessages.get('errors'),
         },
 
         /**
@@ -296,7 +296,7 @@ test.group('Frameworks | SSR', (group) => {
          */
         ssr: {
           enabled: true,
-          entrypoint: 'resources/ssr.tsx'
+          entrypoint: 'inertia/app/ssr.tsx'
         }
       })"
     `)
@@ -311,14 +311,14 @@ test.group('Frameworks | SSR', (group) => {
 
     const command = await ace.create(Configure, ['../../index.js'])
     await command.exec()
-    await assert.fileExists('resources/app.tsx')
+    await assert.fileExists('inertia/app/app.tsx')
     await assert.fileContains(
       'vite.config.ts',
-      `inertia({ ssr: { enabled: true, entrypoint: 'resources/ssr.tsx' } })`
+      `inertia({ ssr: { enabled: true, entrypoint: 'inertia/app/ssr.tsx' } })`
     )
 
     await assert.fileContains('vite.config.ts', `solid({ ssr: true })`)
-    await assert.fileContains('resources/app.tsx', 'hydrate')
+    await assert.fileContains('inertia/app/app.tsx', 'hydrate')
 
     const inertiaConfig = await fs.contents('config/inertia.ts')
     assert.snapshot(inertiaConfig).matchInline(`
@@ -334,7 +334,7 @@ test.group('Frameworks | SSR', (group) => {
          * Data that should be shared with all rendered pages
          */
         sharedData: {
-          errors: (ctx) => ctx.session.flashMessages.get('errors'),
+          errors: (ctx) => ctx.session?.flashMessages.get('errors'),
         },
 
         /**
@@ -342,7 +342,7 @@ test.group('Frameworks | SSR', (group) => {
          */
         ssr: {
           enabled: true,
-          entrypoint: 'resources/ssr.tsx'
+          entrypoint: 'inertia/app/ssr.tsx'
         }
       })"
     `)
@@ -358,11 +358,11 @@ test.group('Frameworks | SSR', (group) => {
     const command = await ace.create(Configure, ['../../index.js'])
     await command.exec()
 
-    await assert.fileExists('resources/app.ts')
+    await assert.fileExists('inertia/app/app.ts')
     await assert.fileExists('resources/views/root.edge')
-    await assert.fileExists('resources/tsconfig.json')
-    await assert.fileExists('resources/pages/home.svelte')
-    await assert.fileContains('resources/app.ts', 'hydrate')
+    await assert.fileExists('inertia/tsconfig.json')
+    await assert.fileExists('inertia/pages/home.svelte')
+    await assert.fileContains('inertia/app/app.ts', 'hydrate')
 
     const viteConfig = await fs.contents('vite.config.ts')
     assert.snapshot(viteConfig).matchInline(`
@@ -370,7 +370,7 @@ test.group('Frameworks | SSR', (group) => {
       import { svelte } from '@sveltejs/vite-plugin-svelte'
       import adonisjs from '@adonisjs/vite/client'
 
-      export default { plugins: [inertia({ ssr: { enabled: true, entrypoint: 'resources/ssr.ts' } }), svelte({ compilerOptions: { hydratable: true } }), adonisjs({ entrypoints: ['resources/app.ts'], reload: ['resources/views/**/*.edge'] })] }
+      export default { plugins: [inertia({ ssr: { enabled: true, entrypoint: 'inertia/app/ssr.ts' } }), svelte({ compilerOptions: { hydratable: true } }), adonisjs({ entrypoints: ['inertia/app/app.ts'], reload: ['resources/views/**/*.edge'] })] }
       "
     `)
   })

--- a/tests/configure.spec.ts
+++ b/tests/configure.spec.ts
@@ -113,6 +113,8 @@ test.group('Frameworks', (group) => {
     await assert.fileExists('resources/views/root.edge')
     await assert.fileExists('inertia/tsconfig.json')
     await assert.fileExists('inertia/pages/home.vue')
+    await assert.fileExists('inertia/pages/errors/not_found.vue')
+    await assert.fileExists('inertia/pages/errors/server_error.vue')
     await assert.fileContains('inertia/app/app.ts', 'createApp')
 
     const viteConfig = await fs.contents('vite.config.ts')
@@ -140,6 +142,8 @@ test.group('Frameworks', (group) => {
     await assert.fileExists('resources/views/root.edge')
     await assert.fileExists('inertia/tsconfig.json')
     await assert.fileExists('inertia/pages/home.tsx')
+    await assert.fileExists('inertia/pages/errors/not_found.tsx')
+    await assert.fileExists('inertia/pages/errors/server_error.tsx')
     await assert.fileContains('inertia/app/app.tsx', 'createRoot')
 
     const viteConfig = await fs.contents('vite.config.ts')
@@ -167,6 +171,8 @@ test.group('Frameworks', (group) => {
     await assert.fileExists('resources/views/root.edge')
     await assert.fileExists('inertia/tsconfig.json')
     await assert.fileExists('inertia/pages/home.tsx')
+    await assert.fileExists('inertia/pages/errors/not_found.tsx')
+    await assert.fileExists('inertia/pages/errors/server_error.tsx')
     await assert.fileNotContains('inertia/app/app.tsx', 'hydrateRoot')
 
     const viteConfig = await fs.contents('vite.config.ts')
@@ -194,6 +200,8 @@ test.group('Frameworks', (group) => {
     await assert.fileExists('resources/views/root.edge')
     await assert.fileExists('inertia/tsconfig.json')
     await assert.fileExists('inertia/pages/home.svelte')
+    await assert.fileExists('inertia/pages/errors/not_found.svelte')
+    await assert.fileExists('inertia/pages/errors/server_error.svelte')
     await assert.fileNotContains('inertia/app/app.ts', 'hydrate')
 
     const viteConfig = await fs.contents('vite.config.ts')

--- a/tests/configure.spec.ts
+++ b/tests/configure.spec.ts
@@ -27,10 +27,9 @@ async function setupFakeAdonisproject(fs: FileSystem) {
 
       router.use([
         () => import('@adonisjs/core/bodyparser_middleware'),
-        () => import('@adonisjs/session/session_middleware'),
-        () => import('@adonisjs/shield/shield_middleware'),
-        () => import('@adonisjs/auth/initialize_auth_middleware'),
       ])
+
+      server.use([])
     `
     ),
   ])

--- a/tests/define_config.spec.ts
+++ b/tests/define_config.spec.ts
@@ -16,7 +16,7 @@ import { setupApp } from '../tests_helpers/index.js'
 
 test.group('Define Config', () => {
   test('detect entrypoint automatically - "{$self}"')
-    .with(['resources/application/app.tsx', 'resources/app.ts', 'resources/app.tsx'])
+    .with(['inertia/app/app.tsx', 'resources/app.ts', 'resources/app.tsx'])
     .run(async ({ assert, fs }, filePath) => {
       const { app } = await setupApp()
       const configProvider = defineConfig({})
@@ -40,7 +40,7 @@ test.group('Define Config', () => {
     })
 
   test('detect ssr entrypoint automatically - "{$self}"')
-    .with(['resources/application/ssr.tsx', 'resources/ssr.ts', 'resources/ssr.tsx'])
+    .with(['inertia/app/ssr.tsx', 'resources/ssr.ts', 'resources/ssr.tsx'])
     .run(async ({ assert, fs }, filePath) => {
       const { app } = await setupApp()
       const configProvider = defineConfig({})

--- a/tests/inertia.spec.ts
+++ b/tests/inertia.spec.ts
@@ -55,7 +55,7 @@ test.group('Inertia', () => {
     const inertia = await new InertiaFactory().create()
     const result: any = await inertia.render('foo', { foo: 'bar' })
 
-    assert.deepEqual(result.view, 'root')
+    assert.deepEqual(result.view, 'inertia_layout')
     assert.deepEqual(result.props.page, {
       component: 'foo',
       version: '1',


### PR DESCRIPTION
We move to a new file structure for inertia apps : 
![image](https://github.com/adonisjs/inertia/assets/8337858/d2b9998f-dd34-4791-9784-8a8025b59e0a)

- All code related to inertia will now be located in `./inertia` folder instead of `./resources/`
- We group app initialization files to `./inertia/app` folder
- We have now a `@adonisjs/tsconfig/tsconfig.client.json` from which we extends. it is a more clean
- Use Inertia in exception handler instead of edge
- Automatically add two `server_error` and `not_found` component pages
