### PR TITLE
fix(react): path imports config stubs

### DIFF
--- a/stubs/react/tsconfig.json.stub
+++ b/stubs/react/tsconfig.json.stub
@@ -8,7 +8,7 @@
     "module": "ESNext",
     "jsx": "react-jsx",
     "paths": {
-      "~/*": ["../*"],
+      "~/*": ["./*"],
     },
   },
   "include": ["./**/*.ts", "./**/*.tsx"],


### PR DESCRIPTION
### ❓ Type of change

- [ x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I found out that the configured path in tsconfig for react was not correct, it was `../` instead of `./` unlike others providers (Vue or Svelte).

This result in a bad import situation on frontend side.