### PR TITLE
Fix error when passing model with @computed() or pagination to Inertia.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@japa/runner": "3.1.2",
     "@japa/snapshot": "^2.0.5",
     "@swc/core": "^1.4.12",
+    "@types/luxon": "^3.4.2",
     "@types/node": "^20.12.4",
     "@types/qs": "^6.9.14",
     "@types/supertest": "^6.0.2",
@@ -75,15 +76,16 @@
   },
   "dependencies": {
     "@poppinss/utils": "^6.7.3",
-    "@tuyau/utils": "^0.0.1",
     "crc-32": "^1.2.2",
     "edge-error": "^4.0.1",
     "html-entities": "^2.5.2",
     "locate-path": "^7.2.0",
+    "luxon": "^3.4.4",
     "qs": "^6.12.0"
   },
   "peerDependencies": {
     "@adonisjs/core": "^6.2.0",
+    "@adonisjs/lucid": "^20.0.0",
     "@adonisjs/session": "^7.0.0",
     "@adonisjs/vite": "^3.0.0-8",
     "@japa/api-client": "^2.0.0",

--- a/src/inertia.ts
+++ b/src/inertia.ts
@@ -21,6 +21,7 @@ import type {
   ResolvedConfig,
   SharedData,
 } from './types.js'
+import { serialize } from './serialize.js'
 
 /**
  * Symbol used to identify lazy props
@@ -105,10 +106,14 @@ export class Inertia {
     component: string,
     pageProps?: TPageProps
   ): Promise<PageObject<TPageProps>> {
+    const serializedPageProps = serialize(pageProps || {})
     return {
       component,
       version: this.config.versionCache.getVersion(),
-      props: await this.#resolvePageProps(component, { ...this.#sharedData, ...pageProps }),
+      props: await this.#resolvePageProps(component, {
+        ...this.#sharedData,
+        ...serializedPageProps,
+      }),
       url: this.ctx.request.url(true),
     }
   }

--- a/src/lucid.ts
+++ b/src/lucid.ts
@@ -1,0 +1,106 @@
+import { LucidModel, ModelPaginatorContract } from '@adonisjs/lucid/types/model'
+import { DateTime } from 'luxon'
+
+export type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & {}
+
+/**
+ * The `InstanceTypeModel` type is a helper type that is used to infer the instance type of a `LucidModel`
+ */
+type InstanceTypeModel = InstanceType<LucidModel>
+
+/**
+ * The `KeysOfInstanceTypeModel` type is a helper type that is used to extract the keys of the `InstanceTypeModel`
+ */
+type KeysOfInstanceTypeModel = keyof InstanceTypeModel
+
+/**
+ * The `KeysOfInstanceTypeRelations` type is a helper type that extends `KeysOfInstanceTypeModel`
+ * and includes additional keys used in the ORM relationships such as 'instance', 'model',
+ * 'client', 'builder', 'subQuery', and '__opaque_type'.
+ */
+type KeysOfInstanceTypeRelations =
+  | KeysOfInstanceTypeModel
+  | 'instance'
+  | 'model'
+  | 'client'
+  | 'builder'
+  | 'subQuery'
+  | '__opaque_type'
+
+/**
+ * The `Primitive` type is a helper type that defines the basic types that can be inferred
+ */
+type Primitive = string | number | boolean | undefined | null | Date
+
+/**
+ * The `DeepInferTypeModelHelper` is a recursive type that infers the type of the properties within a model.
+ * It uses the `KeysOfInstanceTypeModel` and `Primitive` helper types to infer the type of properties.
+ * `T` is the type of the model, `K` is the keys that are excluded from the inference.
+ */
+type DeepInferTypeModelHelper<T, K extends keyof T> = {
+  [P in K]: T[P] extends infer O
+    ? O extends Primitive
+      ? O
+      : O extends DateTime
+        ? Date
+        : O extends InstanceTypeModel[]
+          ? DeepInferTypeModelArray<Omit<O, KeysOfInstanceTypeRelations>, K>[number][]
+          : DeepInferTypeModel<O, K | KeysOfInstanceTypeRelations>
+    : never
+}
+
+/**
+ * The `DeepInferTypeModelArray` type is a helper type that infers the type of array properties within a model.
+ * `T` is the type of the model, `K` is the keys that are excluded from the inference.
+ */
+type DeepInferTypeModelArray<T, K> = Prettify<{
+  [P in keyof T]: DeepInferTypeModel<T[P], KeysOfInstanceTypeRelations | K>
+}>
+
+/**
+ * The `DeepInferTypeModel` type is a recursive type that infers the type of the properties within a model.
+ * It uses the `KeysOfInstanceTypeModel` and `Primitive` helper types to infer the type of properties.
+ * `T` is the type of the model, `K` is the keys that are excluded from the inference.
+ */
+type DeepInferTypeModel<T, K> = T extends Primitive
+  ? T
+  : Prettify<DeepInferTypeModelHelper<T, Exclude<keyof T, K>>>
+
+/**
+ * The `InferTypeModel` type is the final exported type that can be used to infer the types of properties
+ * within a Lucid ORM model. It uses the `DeepInferTypeModel` and `KeysOfInstanceTypeModel` helper types
+ * to infer the types of properties within the model.
+ * `Model` is the type of the model you want to infer the properties from, `K` is the keys that are excluded from the inference.
+ */
+export type InferTypeModel<Model, K extends keyof Model = never> = Prettify<
+  DeepInferTypeModel<Model, K | KeysOfInstanceTypeModel>
+>
+
+export type Infer<T extends object> = {
+  [K in keyof T]: T[K] extends ModelPaginatorContract<infer R>
+    ? {
+        data: InferTypeModel<R>[]
+        meta: {
+          total: number
+          perPage: number
+          currentPage: number
+          lastPage: number
+          firstPage: number
+          firstPageUrl: string
+          lastPageUrl: string
+          nextPageUrl: string
+          previousPageUrl: string
+        }
+      }
+    : T[K] extends Array<infer R>
+      ? InferTypeModel<R>[]
+      : T[K] extends Array<infer R> | undefined
+        ? InferTypeModel<R>[] | undefined
+        : {
+            [P in keyof T[K]]: T[K][P] extends Array<infer R>
+              ? InferTypeModel<R>[]
+              : InferTypeModel<T[K][P]>
+          }
+}

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,0 +1,42 @@
+import { LucidRow, ModelObject, ModelPaginatorContract } from '@adonisjs/lucid/types/model'
+import { BaseModel } from '@adonisjs/lucid/orm'
+import { SimplePaginator } from '@adonisjs/lucid/database'
+import { Infer, Prettify } from './lucid.js'
+
+function serializeModel(model: LucidRow): ModelObject
+function serializeModel(model: LucidRow[]): ModelObject[]
+function serializeModel(model: any) {
+  if (Array.isArray(model)) {
+    return model.map((m) => serializeModel(m))
+  }
+
+  return model.serialize()
+}
+
+function serializePagination(paginator: ModelPaginatorContract<any>) {
+  const { meta, data } = paginator.toJSON()
+  return {
+    data: serializeModel(data as any),
+    meta,
+  }
+}
+
+export function serialize<T extends object>(props: T): Prettify<Infer<T>> {
+  return Object.keys(props).reduce((acc, key) => {
+    const value = props[key as keyof T]
+
+    if (value instanceof SimplePaginator) {
+      return { ...acc, [key]: serializePagination(value as any) }
+    }
+
+    if (value instanceof BaseModel) {
+      return { ...acc, [key]: serializeModel(value) }
+    }
+
+    if (Array.isArray(value)) {
+      return { ...acc, [key]: value.map((v) => (v instanceof BaseModel ? serializeModel(v) : v)) }
+    }
+
+    return { ...acc, [key]: value }
+  }, {} as any)
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,10 +7,10 @@
  * file that was distributed with this source code.
  */
 
-import type { Serialize } from '@tuyau/utils/types'
 import type { HttpContext } from '@adonisjs/core/http'
 
 import type { VersionCache } from './version_cache.js'
+import { Infer, Prettify } from './lucid.js'
 
 export type MaybePromise<T> = T | Promise<T>
 
@@ -125,7 +125,7 @@ export type InferPageProps<
   Controller,
   Method extends keyof Controller,
 > = Controller[Method] extends (...args: any[]) => any
-  ? Serialize<Exclude<Awaited<ReturnType<Controller[Method]>>, string>['props']>
+  ? Prettify<Infer<Exclude<Awaited<ReturnType<Controller[Method]>>, string>['props']>>
   : never
 
 /**


### PR DESCRIPTION
### 🔗 Linked issue

Error passing model with @computed() or pagination to Inertia.js #19

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hello team,

I would like to report a problem I have encountered when dealing with models that contain `@computed()` or when passing pagination to Inertia.js in my project. When doing so, an error occurs within the @adonisjs/inertiajs package.

To resolve this issue in my project, I developed a serialization method before passing the data to Inertia.js. This approach allowed me to reprocess the data or send it to the browser without encountering the aforementioned error.

In addition, I took the opportunity to update a type I had created for a provider previously used with `@pyxlab/adonis-trpc` in Adonis. I modified the return from InferPageProps to return Infer instead of Serialize. This was done because the Serialize type only returned ModelObject when a model was passed in.

I'm happy to provide more details or help you solve this problem.

<!--
### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
-->
