### PR TITLE
fix: handle properly null and undefined props values

### DIFF
--- a/src/inertia.ts
+++ b/src/inertia.ts
@@ -103,7 +103,11 @@ export class Inertia {
      */
     if (!isPartial) {
       newProps = Object.fromEntries(
-        Object.entries(props).filter(([_, value]) => !(value as any)[ignoreFirstLoadSymbol])
+        Object.entries(props).filter(([_, value]) => {
+          if (value && (value as any)[ignoreFirstLoadSymbol]) return false
+
+          return true
+        })
       )
     }
 

--- a/tests/inertia.spec.ts
+++ b/tests/inertia.spec.ts
@@ -212,6 +212,22 @@ test.group('Inertia', () => {
     assert.deepEqual(result.mergeProps, ['baz', 'bar'])
   })
 
+  test('properly handle null and undefined values props on first visit', async ({ assert }) => {
+    setupViewMacroMock()
+
+    const inertia = await new InertiaFactory().create()
+
+    const result: any = await inertia.render('Auth/Login', {
+      user: undefined,
+      password: null,
+      message: 'hello',
+    })
+
+    assert.deepEqual(result.props.page.props, {
+      message: 'hello',
+    })
+  })
+
   test("don't return lazy props on first visit", async ({ assert }) => {
     setupViewMacroMock()
 

--- a/tests/inertia.spec.ts
+++ b/tests/inertia.spec.ts
@@ -225,6 +225,8 @@ test.group('Inertia', () => {
 
     assert.deepEqual(result.props.page.props, {
       message: 'hello',
+      password: null,
+      user: undefined,
     })
   })
 


### PR DESCRIPTION
### 🔗 Linked issue
I didn’t create an issue and instead provide a failing test.


### ❓ Type of change

- [x] 📝 Test to reproduce an issue
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I’m running into `Cannot read properties of undefined (reading 'Symbol(ignoreFirstLoad)')` if a response prop is `null` or `undefined`. We allow props having `string | undefined` values and currently this fails because the code always assumes a value.

I provided a failing test to reproduce the issue.


### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
