### PR TITLE
Rewrote SharedProps Type declaration so usePage is not throwing errors

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -185,12 +185,6 @@ export type InferSharedProps<T extends ConfigProvider<ResolvedConfig>> = Returns
 >
 
 /**
- * The shared props inferred from the user config user-land.
- * Should be module augmented by the user
- */
-export interface SharedProps {}
-
-/**
  * Helper for infering the page props from a Controller method that returns
  * inertia.render
  *
@@ -214,10 +208,7 @@ export type InferPageProps<
   Method extends keyof Controller,
 > = Controller[Method] extends (...args: any[]) => any
   ? Simplify<
-      Serialize<
-        InferProps<Extract<Awaited<ReturnType<Controller[Method]>>, PageObject>['props']> &
-          SharedProps
-      >
+      Serialize<InferProps<Extract<Awaited<ReturnType<Controller[Method]>>, PageObject>['props']>>
     >
   : never
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,6 +185,12 @@ export type InferSharedProps<T extends ConfigProvider<ResolvedConfig>> = Returns
 >
 
 /**
+ * The shared props inferred from the user config user-land.
+ * Should be module augmented by the user
+ */
+export interface SharedProps {}
+
+/**
  * Helper for infering the page props from a Controller method that returns
  * inertia.render
  *
@@ -208,7 +214,10 @@ export type InferPageProps<
   Method extends keyof Controller,
 > = Controller[Method] extends (...args: any[]) => any
   ? Simplify<
-      Serialize<InferProps<Extract<Awaited<ReturnType<Controller[Method]>>, PageObject>['props']>>
+      Serialize<
+        InferProps<Extract<Awaited<ReturnType<Controller[Method]>>, PageObject>['props']> &
+          SharedProps
+      >
     >
   : never
 

--- a/stubs/config.stub
+++ b/stubs/config.stub
@@ -2,7 +2,7 @@
   exports({ to: app.configPath('inertia.ts') })
 }}}
 import { defineConfig } from '@adonisjs/inertia'
-import type { InferSharedProps } from '@adonisjs/inertia/types'
+import type { InferSharedProps, PageProps } from '@adonisjs/inertia/types'
 
 const inertiaConfig = defineConfig({
   /**
@@ -29,5 +29,5 @@ const inertiaConfig = defineConfig({
 export default inertiaConfig
 
 declare module '@adonisjs/inertia/types' {
-  export type SharedProps = InferSharedProps<typeof inertiaConfig> & {}
+  export interface SharedProps extends InferSharedProps<typeof inertiaConfig>, PageProps {}
 }

--- a/stubs/config.stub
+++ b/stubs/config.stub
@@ -29,5 +29,5 @@ const inertiaConfig = defineConfig({
 export default inertiaConfig
 
 declare module '@adonisjs/inertia/types' {
-  export interface SharedProps extends InferSharedProps<typeof inertiaConfig> {}
+  export type SharedProps = InferSharedProps<typeof inertiaConfig> & {}
 }

--- a/tests/configure.spec.ts
+++ b/tests/configure.spec.ts
@@ -261,7 +261,7 @@ test.group('Frameworks | SSR', (group) => {
       export default inertiaConfig
 
       declare module '@adonisjs/inertia/types' {
-        export interface SharedProps extends InferSharedProps<typeof inertiaConfig> {}
+        export type SharedProps = InferSharedProps<typeof inertiaConfig> & {}
       }"
     `)
   })
@@ -314,7 +314,7 @@ test.group('Frameworks | SSR', (group) => {
       export default inertiaConfig
 
       declare module '@adonisjs/inertia/types' {
-        export interface SharedProps extends InferSharedProps<typeof inertiaConfig> {}
+        export type SharedProps = InferSharedProps<typeof inertiaConfig> & {}
       }"
     `)
   })
@@ -367,7 +367,7 @@ test.group('Frameworks | SSR', (group) => {
       export default inertiaConfig
 
       declare module '@adonisjs/inertia/types' {
-        export interface SharedProps extends InferSharedProps<typeof inertiaConfig> {}
+        export type SharedProps = InferSharedProps<typeof inertiaConfig> & {}
       }"
     `)
   })

--- a/tests/configure.spec.ts
+++ b/tests/configure.spec.ts
@@ -234,7 +234,7 @@ test.group('Frameworks | SSR', (group) => {
     const inertiaConfig = await fs.contents('config/inertia.ts')
     assert.snapshot(inertiaConfig).matchInline(`
       "import { defineConfig } from '@adonisjs/inertia'
-      import type { InferSharedProps } from '@adonisjs/inertia/types'
+      import type { InferSharedProps, PageProps } from '@adonisjs/inertia/types'
 
       const inertiaConfig = defineConfig({
         /**
@@ -261,7 +261,7 @@ test.group('Frameworks | SSR', (group) => {
       export default inertiaConfig
 
       declare module '@adonisjs/inertia/types' {
-        export type SharedProps = InferSharedProps<typeof inertiaConfig> & {}
+        export interface SharedProps extends InferSharedProps<typeof inertiaConfig>, PageProps {}
       }"
     `)
   })
@@ -287,7 +287,7 @@ test.group('Frameworks | SSR', (group) => {
 
     assert.snapshot(inertiaConfig).matchInline(`
       "import { defineConfig } from '@adonisjs/inertia'
-      import type { InferSharedProps } from '@adonisjs/inertia/types'
+      import type { InferSharedProps, PageProps } from '@adonisjs/inertia/types'
 
       const inertiaConfig = defineConfig({
         /**
@@ -314,7 +314,7 @@ test.group('Frameworks | SSR', (group) => {
       export default inertiaConfig
 
       declare module '@adonisjs/inertia/types' {
-        export type SharedProps = InferSharedProps<typeof inertiaConfig> & {}
+        export interface SharedProps extends InferSharedProps<typeof inertiaConfig>, PageProps {}
       }"
     `)
   })
@@ -340,7 +340,7 @@ test.group('Frameworks | SSR', (group) => {
     const inertiaConfig = await fs.contents('config/inertia.ts')
     assert.snapshot(inertiaConfig).matchInline(`
       "import { defineConfig } from '@adonisjs/inertia'
-      import type { InferSharedProps } from '@adonisjs/inertia/types'
+      import type { InferSharedProps, PageProps } from '@adonisjs/inertia/types'
 
       const inertiaConfig = defineConfig({
         /**
@@ -367,7 +367,7 @@ test.group('Frameworks | SSR', (group) => {
       export default inertiaConfig
 
       declare module '@adonisjs/inertia/types' {
-        export type SharedProps = InferSharedProps<typeof inertiaConfig> & {}
+        export interface SharedProps extends InferSharedProps<typeof inertiaConfig>, PageProps {}
       }"
     `)
   })


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

#46 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

By rewriting the config template like this: 

```TypeScript
declare module '@adonisjs/inertia/types' {
  export type SharedProps = InferSharedProps<typeof inertiaConfig> & {}
}
```

and by removing this interface declaration from the `types`:

```TypeScript
export interface SharedProps {}
```
The `SharedProps` type is easily extended by the user like this: 

```TypeScript
declare module '@adonisjs/inertia/types' {
  export type SharedProps = InferSharedProps<typeof inertiaConfig> & {
      prop1: number
      prop2: string
  }
}
```

and the `usePage` hook from `@inertia/react` is able to deduce the prop type declared here as well.

![inertia_prop_type_extended](https://github.com/user-attachments/assets/1d2b75d1-71cf-40e3-9e75-199353c1e788)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
