### PR TITLE
fix: use updated svelte 5 functions

### DIFF
--- a/stubs/svelte/app.ts.stub
+++ b/stubs/svelte/app.ts.stub
@@ -8,6 +8,7 @@ import '../css/app.css';
 
 import { createInertiaApp } from '@inertiajs/svelte'
 import { resolvePageComponent } from '@adonisjs/inertia/helpers'
+import { hydrate, mount } from 'svelte'
 
 const appName = import.meta.env.VITE_APP_NAME || 'AdonisJS'
 
@@ -24,10 +25,10 @@ createInertiaApp({
   },
 
   setup({ el, App, props }) {
-    {{#if ssr}}
-    new App({ target: el, props, hydrate: true })
-    {{#else}}
-    new App({ target: el, props })
-    {{/if}}
+    if (el.dataset.serverRendered === 'true') {
+      hydrate(App, { target: el, props })
+    } else {
+      mount(App, { target: el, props })
+    }
   },
 })

--- a/stubs/svelte/ssr.ts.stub
+++ b/stubs/svelte/ssr.ts.stub
@@ -3,6 +3,7 @@
 }}}
 
 import { createInertiaApp } from '@inertiajs/svelte'
+import { render as svelteRender } from 'svelte/server'
 
 export default function render(page: any) {
   return createInertiaApp({
@@ -10,6 +11,9 @@ export default function render(page: any) {
     resolve: (name) => {
       const pages = import.meta.glob('../pages/**/*.svelte', { eager: true })
       {{ 'return pages[`../pages/${name}.svelte`]' }}
-    }
+    },
+    setup({ el, App, props }) {
+      return svelteRender(App, { props })
+    },
   })
 }


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

https://github.com/adonisjs/inertia-starter-kit/issues/7

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Svelte 5 changes how the applications is mounted, the inertia adapter needs to change to support them. I've also removed the SSR check in the template, now matching the behaviour used by the Laravel adapter.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
