### PR TITLE
Revert "fix: make SharedProps compatible with inertia usePage"

### DIFF
--- a/stubs/config.stub
+++ b/stubs/config.stub
@@ -2,7 +2,7 @@
   exports({ to: app.configPath('inertia.ts') })
 }}}
 import { defineConfig } from '@adonisjs/inertia'
-import type { InferSharedProps, PageProps } from '@adonisjs/inertia/types'
+import type { InferSharedProps } from '@adonisjs/inertia/types'
 
 const inertiaConfig = defineConfig({
   /**
@@ -29,5 +29,5 @@ const inertiaConfig = defineConfig({
 export default inertiaConfig
 
 declare module '@adonisjs/inertia/types' {
-  export interface SharedProps extends InferSharedProps<typeof inertiaConfig>, PageProps {}
+  export interface SharedProps extends InferSharedProps<typeof inertiaConfig> {}
 }

--- a/tests/configure.spec.ts
+++ b/tests/configure.spec.ts
@@ -233,7 +233,7 @@ test.group('Frameworks | SSR', (group) => {
     const inertiaConfig = await fs.contents('config/inertia.ts')
     assert.snapshot(inertiaConfig).matchInline(`
       "import { defineConfig } from '@adonisjs/inertia'
-      import type { InferSharedProps, PageProps } from '@adonisjs/inertia/types'
+      import type { InferSharedProps } from '@adonisjs/inertia/types'
 
       const inertiaConfig = defineConfig({
         /**
@@ -260,7 +260,7 @@ test.group('Frameworks | SSR', (group) => {
       export default inertiaConfig
 
       declare module '@adonisjs/inertia/types' {
-        export interface SharedProps extends InferSharedProps<typeof inertiaConfig>, PageProps {}
+        export interface SharedProps extends InferSharedProps<typeof inertiaConfig> {}
       }"
     `)
   })
@@ -286,7 +286,7 @@ test.group('Frameworks | SSR', (group) => {
 
     assert.snapshot(inertiaConfig).matchInline(`
       "import { defineConfig } from '@adonisjs/inertia'
-      import type { InferSharedProps, PageProps } from '@adonisjs/inertia/types'
+      import type { InferSharedProps } from '@adonisjs/inertia/types'
 
       const inertiaConfig = defineConfig({
         /**
@@ -313,7 +313,7 @@ test.group('Frameworks | SSR', (group) => {
       export default inertiaConfig
 
       declare module '@adonisjs/inertia/types' {
-        export interface SharedProps extends InferSharedProps<typeof inertiaConfig>, PageProps {}
+        export interface SharedProps extends InferSharedProps<typeof inertiaConfig> {}
       }"
     `)
   })
@@ -339,7 +339,7 @@ test.group('Frameworks | SSR', (group) => {
     const inertiaConfig = await fs.contents('config/inertia.ts')
     assert.snapshot(inertiaConfig).matchInline(`
       "import { defineConfig } from '@adonisjs/inertia'
-      import type { InferSharedProps, PageProps } from '@adonisjs/inertia/types'
+      import type { InferSharedProps } from '@adonisjs/inertia/types'
 
       const inertiaConfig = defineConfig({
         /**
@@ -366,7 +366,7 @@ test.group('Frameworks | SSR', (group) => {
       export default inertiaConfig
 
       declare module '@adonisjs/inertia/types' {
-        export interface SharedProps extends InferSharedProps<typeof inertiaConfig>, PageProps {}
+        export interface SharedProps extends InferSharedProps<typeof inertiaConfig> {}
       }"
     `)
   })


### PR DESCRIPTION
[This PR](https://github.com/adonisjs/inertia/pull/50) broke `InferPageProps`. For example :

```ts
export default function Home(props: InferPageProps<TestsController, 'login'>) {
  props
  // ^? { [x: string]: never; [x: number]: never; }
}
```

`props` will always be equal to `{ [x: string]: never; [x: number]: never; }` no matter what we do. 

cc @Barabasbalazs 