### PR TITLE
Adding dumper stack to root edge pages

### DIFF
--- a/stubs/react/root.edge.stub
+++ b/stubs/react/root.edge.stub
@@ -63,6 +63,7 @@
     }
   </script>
 
+  @stack('dumper')
   @viteReactRefresh()
   @inertiaHead()
   {{ "@vite(['inertia/app/app.tsx', `inertia/pages/${page.component}.tsx`])" }}

--- a/stubs/solid/root.edge.stub
+++ b/stubs/solid/root.edge.stub
@@ -61,6 +61,7 @@
     }
   </script>
 
+  @stack('dumper')
   @inertiaHead()
   {{ "@vite(['inertia/app/app.tsx', `inertia/pages/${page.component}.tsx`])" }}
 </head>

--- a/stubs/svelte/root.edge.stub
+++ b/stubs/svelte/root.edge.stub
@@ -65,6 +65,7 @@
 
   {{ "@vite(['inertia/app/app.ts', `inertia/pages/${page.component}.svelte`])" }}
   @inertiaHead()
+  @stack('dumper')
 </head>
 
 <body class="min-h-screen w-screen font-sans">

--- a/stubs/vue/root.edge.stub
+++ b/stubs/vue/root.edge.stub
@@ -65,6 +65,7 @@
 
   {{ "@vite(['inertia/app/app.ts', `inertia/pages/${page.component}.vue`])" }}
   @inertiaHead()
+  @stack('dumper')
 </head>
 
 <body class="min-h-screen w-screen font-sans">


### PR DESCRIPTION
### 🔗 Linked issue

Related Discussion: https://github.com/orgs/adonisjs/discussions/4844

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adding `@stack('dumper')` to the EdgeJS root page stubs so that the script & styles get added out-of-the-box when using the `@dump` helper.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
