### PR TITLE
add @japa/api-client 3.x to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@adonisjs/assembler": "^7.8.2",
-    "@adonisjs/core": "6.16.0",
+    "@adonisjs/core": "6.17.1",
     "@adonisjs/eslint-config": "^2.0.0-beta.7",
     "@adonisjs/prettier-config": "^1.4.0",
     "@adonisjs/session": "7.5.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@adonisjs/core": "^6.9.1",
     "@adonisjs/session": "^7.4.0",
     "@adonisjs/vite": "^4.0.0",
-    "@japa/api-client": "^2.0.0",
+    "@japa/api-client": "^2.0.0 || ^3.0.0",
     "edge.js": "^6.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
### 🔗 Linked issue
No related issue.


### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)


### 📚 Description
Add the `@japa/api-client` 3.x release line to peerDependencies. Keeps `@japa/api-client` 2.x releases as well.


### 📝 Checklist
- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
