### PR TITLE
(Type) Add errors to PageProps

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ export type MaybePromise<T> = T | Promise<T>
 /**
  * Props that will be passed to inertia render method
  */
-export type PageProps = Record<string, unknown>
+export type PageProps = Record<string, unknown> & { errors: Record<string, string | string[]> }
 
 /**
  * Shared data types


### PR DESCRIPTION
In relation to the latest updates, as errors are now shared by the adaptor.

<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add errors as default PageProps type — in relation to the latest updates, since errors are now shared by the adapter. However, I think the best way would be to add a new type, e.g. "ErrorsBag", because it's a repetitive type of ``session.flashErrors`` ; but that would require updating adonisjs/core.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
