### PR TITLE
fix: error on render when session is undefined

### DIFF
--- a/src/inertia_middleware.ts
+++ b/src/inertia_middleware.ts
@@ -42,6 +42,13 @@ export default class InertiaMiddleware {
   #resolveValidationErrors(ctx: HttpContext) {
     const { session, request } = ctx
 
+    // If the session middleware wasn't executed
+    // (on routes that are not in the router, for instance),
+    // then the session object will be undefined.
+    if (!session) {
+      return {}
+    }
+
     /**
      * If not a Vine Validation error, then return the entire error bag
      */

--- a/tests/middleware.spec.ts
+++ b/tests/middleware.spec.ts
@@ -396,4 +396,37 @@ test.group('Middleware | Errors', () => {
       errors: { foo: 'bar', bar: 'baz' },
     })
   })
+
+  test('if session isn\t initialized, doesn\t throw an error', async ({ assert }) => {
+    const middleware = new InertiaMiddleware({
+      rootView: 'root',
+      sharedData: {},
+      versionCache: new VersionCache(new URL(import.meta.url), '1'),
+      ssr: { enabled: false, bundle: '', entrypoint: '' },
+      history: { encrypt: false },
+    })
+
+    const server = httpServer.create(async (req, res) => {
+      const request = new RequestFactory().merge({ req, res }).create()
+      const response = new ResponseFactory().merge({ req, res }).create()
+      const ctx = new HttpContextFactory().merge({ request, response }).create()
+
+      await middleware.handle(ctx, () => {})
+
+      try {
+        ctx.response.json(await ctx.inertia.render('foo'))
+      } catch (error) {
+        ctx.response.internalServerError()
+      } finally {
+        ctx.response.finish()
+      }
+    })
+
+    const r1 = await supertest(server)
+      .post('/')
+      .set(InertiaHeaders.Inertia, 'true')
+      .set(InertiaHeaders.Version, '1')
+
+    assert.equal(r1.status, 200)
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Closes #58.

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Closes #58.

As described in the issue, the session needs to be checked to see if it is undefined before reading the flashMessages from it.

I have also added a test to prevent regressions in the future.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly. [not needed in this PR]
