### PR TITLE
test: fail tests on callback errors

### DIFF
--- a/tests/middleware.spec.ts
+++ b/tests/middleware.spec.ts
@@ -397,7 +397,7 @@ test.group('Middleware | Errors', () => {
     })
   })
 
-  test('if session isn\t initialized, doesn\t throw an error', async ({ assert }) => {
+  test("if session isn't initialized, doesn't throw an error", async ({ assert }) => {
     const middleware = new InertiaMiddleware({
       rootView: 'root',
       sharedData: {},

--- a/tests/middleware.spec.ts
+++ b/tests/middleware.spec.ts
@@ -397,7 +397,7 @@ test.group('Middleware | Errors', () => {
     })
   })
 
-  test("if session isn't initialized, doesn't throw an error", async ({ assert }) => {
+  test("if session isn't initialized, doesn't throw an error", async () => {
     const middleware = new InertiaMiddleware({
       rootView: 'root',
       sharedData: {},
@@ -413,20 +413,13 @@ test.group('Middleware | Errors', () => {
 
       await middleware.handle(ctx, () => {})
 
-      try {
-        ctx.response.json(await ctx.inertia.render('foo'))
-      } catch (error) {
-        ctx.response.internalServerError()
-      } finally {
-        ctx.response.finish()
-      }
+      ctx.response.json(await ctx.inertia.render('foo'))
+      ctx.response.finish()
     })
 
-    const r1 = await supertest(server)
+    await supertest(server)
       .post('/')
       .set(InertiaHeaders.Inertia, 'true')
       .set(InertiaHeaders.Version, '1')
-
-    assert.equal(r1.status, 200)
   })
 })

--- a/tests_helpers/index.ts
+++ b/tests_helpers/index.ts
@@ -27,7 +27,7 @@ function createServerWithErrorHandling(callback: RequestCallback) {
   })
 
   const errors: Error[] = []
-  server.once('clientError', (err) => errors.push(err))
+  server.on('clientError', (err) => errors.push(err))
 
   return {
     server,

--- a/tests_helpers/index.ts
+++ b/tests_helpers/index.ts
@@ -15,18 +15,64 @@ import { inertiaApiClient } from '../src/plugins/japa/api_client.js'
 
 export const BASE_URL = new URL('./tmp/', import.meta.url)
 
+type PromiseFunctions<T> = Parameters<ConstructorParameters<typeof Promise<T>>[0]>
+class PromiseWithResolvers<T> {
+  promise
+  resolve
+  reject
+
+  constructor() {
+    let resolve: PromiseFunctions<T>[0] | null
+    let reject: PromiseFunctions<T>[1] | null
+
+    this.promise = new Promise<T>(($resolve, $reject) => {
+      this.resolve = $resolve
+      this.reject = $reject
+    })
+
+    this.resolve = resolve!
+    this.reject = reject!
+  }
+}
+
+type RequestCallback = (req: IncomingMessage, res: ServerResponse) => any
+
+function createServerWithErrorHandling(callback: RequestCallback) {
+  const errors = new PromiseWithResolvers<void>()
+
+  const server = createServer(async (req, res) => {
+    try {
+      return await callback(req, res)
+    } catch (error) {
+      errors.reject(error)
+      res.destroy(error)
+    }
+  })
+
+  server.on('close', () => errors.resolve())
+
+  return {
+    server,
+    errors,
+  }
+}
+
 /**
  * Create a http server that will be closed automatically
  * when the test ends
  */
 export const httpServer = {
-  create(callback: (req: IncomingMessage, res: ServerResponse) => any) {
-    const server = createServer(callback)
+  create(callback: RequestCallback) {
+    const { server, errors } = createServerWithErrorHandling(callback)
+
     getActiveTest()?.cleanup(async () => {
+      await errors.promise
+
       await new Promise<void>((resolve) => {
         server.close(() => resolve())
       })
     })
+
     return server
   },
 }

--- a/tests_helpers/index.ts
+++ b/tests_helpers/index.ts
@@ -15,41 +15,19 @@ import { inertiaApiClient } from '../src/plugins/japa/api_client.js'
 
 export const BASE_URL = new URL('./tmp/', import.meta.url)
 
-type PromiseFunctions<T> = Parameters<ConstructorParameters<typeof Promise<T>>[0]>
-class PromiseWithResolvers<T> {
-  promise
-  resolve
-  reject
-
-  constructor() {
-    let resolve: PromiseFunctions<T>[0] | null
-    let reject: PromiseFunctions<T>[1] | null
-
-    this.promise = new Promise<T>(($resolve, $reject) => {
-      this.resolve = $resolve
-      this.reject = $reject
-    })
-
-    this.resolve = resolve!
-    this.reject = reject!
-  }
-}
-
 type RequestCallback = (req: IncomingMessage, res: ServerResponse) => any
 
 function createServerWithErrorHandling(callback: RequestCallback) {
-  const errors = new PromiseWithResolvers<void>()
-
   const server = createServer(async (req, res) => {
     try {
       return await callback(req, res)
     } catch (error) {
-      errors.reject(error)
-      res.destroy(error)
+      if (error instanceof Error) res.destroy(error)
     }
   })
 
-  server.on('close', () => errors.resolve())
+  const errors: Error[] = []
+  server.once('clientError', (err) => errors.push(err))
 
   return {
     server,
@@ -66,11 +44,11 @@ export const httpServer = {
     const { server, errors } = createServerWithErrorHandling(callback)
 
     getActiveTest()?.cleanup(async () => {
-      await errors.promise
-
       await new Promise<void>((resolve) => {
         server.close(() => resolve())
       })
+
+      if (errors.length > 0) throw errors[0]
     })
 
     return server


### PR DESCRIPTION
### 🔗 Linked issue

*There isn't an open issue.* I can open one if you'd like, but this is more tooling-related.

### ❓ Type of change

*None, this is related to testing...*

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

So, yesterday, while I was writing the test in #59, I noticed that if the server callback throws an error and it isn't properly handled, the agent idles forever, waiting for the connection to close.

As such, this PR now captures all errors that are thrown in the server callback (including stack traces) and stores them in an array. Only the first error is reported through the test runner. The error fails the test.

(As a side note, this PR also fixes the name of the test in #59)

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
