### PR TITLE
Fix sand color template in React template

### DIFF
--- a/stubs/react/root.edge.stub
+++ b/stubs/react/root.edge.stub
@@ -52,7 +52,7 @@
               6: 'var(--sand-6)',
               7: 'var(--sand-7)',
               8: 'var(--sand-8)',
-              9: 'v and import it herear(--sand-9)',
+              9: 'var(--sand-9)',
               10: 'var(--sand-10)',
               11: 'var(--sand-11)',
               12: 'var(--sand-12)',


### PR DESCRIPTION
### ❓ Type of change

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The color palette is broken, as a mass find-and-replace has gone wrong
