### PR TITLE
fix: return default object if errorsBag is undefined

### DIFF
--- a/src/inertia_middleware.ts
+++ b/src/inertia_middleware.ts
@@ -53,7 +53,7 @@ export default class InertiaMiddleware {
      * If not a Vine Validation error, then return the entire error bag
      */
     if (!session.flashMessages.has('errorsBag.E_VALIDATION_ERROR')) {
-      return session.flashMessages.get('errorsBag')
+      return session.flashMessages.get('errorsBag', {})
     }
 
     /**

--- a/tests/middleware.spec.ts
+++ b/tests/middleware.spec.ts
@@ -397,6 +397,46 @@ test.group('Middleware | Errors', () => {
     })
   })
 
+  test('return default object if errorsBag is undefined', async ({ assert }) => {
+    const middleware = new InertiaMiddleware({
+      rootView: 'root',
+      sharedData: {},
+      versionCache: new VersionCache(new URL(import.meta.url), '1'),
+      ssr: { enabled: false, bundle: '', entrypoint: '' },
+      history: { encrypt: false },
+    })
+
+    const sessionMiddleware = await new SessionMiddlewareFactory().create()
+    const server = httpServer.create(async (req, res) => {
+      const request = new RequestFactory().merge({ req, res }).create()
+      const response = new ResponseFactory().merge({ req, res }).create()
+      const ctx = new HttpContextFactory().merge({ request, response }).create()
+      await sessionMiddleware.handle(ctx, () => {})
+
+      // Do not set errorsBag in session flashMessages
+      await middleware.handle(ctx, () => {})
+
+      ctx.response.json(
+        await ctx.inertia.render('foo', {
+          test: 'value',
+          yeah: 'no',
+        })
+      )
+      ctx.response.finish()
+    })
+
+    const r1 = await supertest(server)
+      .post('/')
+      .set(InertiaHeaders.Inertia, 'true')
+      .set(InertiaHeaders.PartialComponent, 'foo')
+      .set(InertiaHeaders.PartialOnly, 'yeah')
+
+    assert.deepEqual(r1.body.props, {
+      yeah: 'no',
+      errors: {},
+    })
+  })
+
   test('if session isn\t initialized, doesn\t throw an error', async ({ assert }) => {
     const middleware = new InertiaMiddleware({
       rootView: 'root',


### PR DESCRIPTION
### 🔗 Linked issue

None

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In the following case :
- Client: submits an invalid form.
- Server: returns validation errors in the `errors` prop from the session `errorsBag`.
- Client: resubmits the valid form.
- Server: finds no errors inside the `errorsBag`, so the `errors` prop returned is `undefined`.
- Client : does not update the `errors` prop, causing Inertia's `useForm` to still consider there is an error.

This PR resolves the issue by always returning an object in the `#resolveValidationErrors` function, ensuring the `errors` prop is always merged and up to date client-side.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
