### PR TITLE
[FEAT] Support Custom Source In Pages Indexer

### DIFF
--- a/src/index_pages.ts
+++ b/src/index_pages.ts
@@ -69,7 +69,7 @@ type ExtractProps<T> =
  * })
  * ```
  */
-export const indexPages = function (config: { framework: 'vue3' | 'react', source?: string }) {
+export const indexPages = function (config: { framework: 'vue3' | 'react'; source?: string }) {
   if (!SUPPORTED_FRAMEWORKS.includes(config.framework)) {
     throw new Error(
       `Unsupported framework "${config.framework}". Types generation is available only for ${SUPPORTED_FRAMEWORKS.join(',')}`

--- a/src/index_pages.ts
+++ b/src/index_pages.ts
@@ -56,6 +56,7 @@ type ExtractProps<T> =
  *
  * @param config - Configuration object specifying the frontend framework
  * @param config.framework - The frontend framework ('vue3' or 'react')
+ * @param config.source - The path to Inertia pages (default: inertia/pages)
  * @returns Assembler hook object with run method for generating page types
  *
  * @example
@@ -68,7 +69,7 @@ type ExtractProps<T> =
  * })
  * ```
  */
-export const indexPages = function (config: { framework: 'vue3' | 'react' }) {
+export const indexPages = function (config: { framework: 'vue3' | 'react', source?: string }) {
   if (!SUPPORTED_FRAMEWORKS.includes(config.framework)) {
     throw new Error(
       `Unsupported framework "${config.framework}". Types generation is available only for ${SUPPORTED_FRAMEWORKS.join(',')}`
@@ -85,7 +86,7 @@ export const indexPages = function (config: { framework: 'vue3' | 'react' }) {
      */
     run(_, __, indexGenerator) {
       indexGenerator.add('inertiaPages', {
-        source: 'inertia/pages',
+        source: config.source ?? 'inertia/pages',
         glob: GLOB[config.framework],
         output: '.adonisjs/server/pages.d.ts',
         /**

--- a/tests/index_pages.spec.ts
+++ b/tests/index_pages.spec.ts
@@ -48,6 +48,40 @@ test.group('Index pages', () => {
     )
   })
 
+  test('index custom vue pages source', async ({ assert, fs }) => {
+    const cliUi = Kernel.create().ui
+    cliUi.switchMode('raw')
+
+    await fs.create('resources/js/pages/users/index.vue', '')
+    await fs.create('resources/js/pages/users/create.vue', '')
+    await fs.create('resources/js/pages/home.vue', '')
+
+    const generator = new IndexGenerator(stringHelpers.toUnixSlash(fs.basePath), cliUi.logger)
+    const indexer = indexPages({
+      framework: 'vue3',
+      source: 'resources/js/pages',
+    })
+
+    indexer.run({} as any, {} as any, generator)
+    await generator.generate()
+
+    await assert.fileExists('.adonisjs/server/pages.d.ts')
+    await assert.fileContains('.adonisjs/server/pages.d.ts', [
+      `import type { VNodeProps, AllowedComponentProps, ComponentInstance } from 'vue'`,
+      `type ExtractProps<T>`,
+      `declare module '@adonisjs/inertia/types' {`,
+      `export interface InertiaPages {`,
+      `'home': ExtractProps<(typeof import('../../resources/js/pages/home.vue'))['default']>`,
+      `'users/create': ExtractProps<(typeof import('../../resources/js/pages/users/create.vue'))['default']>`,
+      `'users/index': ExtractProps<(typeof import('../../resources/js/pages/users/index.vue'))['default']>`,
+      ``,
+    ])
+    console.log(cliUi.logger.getLogs())
+    assert.isDefined(
+      cliUi.logger.getLogs().find(({ message }) => message.includes('codegen: created 1 file(s)'))
+    )
+  })
+
   test('index react pages', async ({ assert, fs }) => {
     const cliUi = Kernel.create().ui
     cliUi.switchMode('raw')
@@ -73,6 +107,39 @@ test.group('Index pages', () => {
       `'home': ExtractProps<(typeof import('../../inertia/pages/home.tsx'))['default']>`,
       `'users/create': ExtractProps<(typeof import('../../inertia/pages/users/create.tsx'))['default']>`,
       `'users/index': ExtractProps<(typeof import('../../inertia/pages/users/index.tsx'))['default']>`,
+      ``,
+    ])
+    assert.isDefined(
+      cliUi.logger.getLogs().find(({ message }) => message.includes('codegen: created 1 file(s)'))
+    )
+  })
+
+  test('index custom react pages source', async ({ assert, fs }) => {
+    const cliUi = Kernel.create().ui
+    cliUi.switchMode('raw')
+
+    await fs.create('resources/js/pages/users/index.tsx', '')
+    await fs.create('resources/js/pages/users/create.tsx', '')
+    await fs.create('resources/js/pages/home.tsx', '')
+
+    const generator = new IndexGenerator(stringHelpers.toUnixSlash(fs.basePath), cliUi.logger)
+    const indexer = indexPages({
+      framework: 'react',
+      source: 'resources/js/pages',
+    })
+
+    indexer.run({} as any, {} as any, generator)
+    await generator.generate()
+
+    await assert.fileExists('.adonisjs/server/pages.d.ts')
+    await assert.fileContains('.adonisjs/server/pages.d.ts', [
+      `import type React from 'react'`,
+      `type ExtractProps<T>`,
+      `declare module '@adonisjs/inertia/types' {`,
+      `export interface InertiaPages {`,
+      `'home': ExtractProps<(typeof import('../../resources/js/pages/home.tsx'))['default']>`,
+      `'users/create': ExtractProps<(typeof import('../../resources/js/pages/users/create.tsx'))['default']>`,
+      `'users/index': ExtractProps<(typeof import('../../resources/js/pages/users/index.tsx'))['default']>`,
       ``,
     ])
     assert.isDefined(


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Thanks for the work on the pages indexer!

The purpose of this PR is to add a parameter to specify a custom page source, because in my setup, I added the files to `resources/js/pages` to align with regular JavaScript usage and the Shadcn path for a Laravel-like setup.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
