### PR TITLE
fix: renderInertia ``props`` should be optional

### DIFF
--- a/providers/inertia_provider.ts
+++ b/providers/inertia_provider.ts
@@ -51,7 +51,7 @@ declare module '@adonisjs/core/http' {
      */
     renderInertia<Page extends keyof InertiaPages>(
       component: Page,
-      props: InertiaPages[Page] extends ComponentProps
+      props?: InertiaPages[Page] extends ComponentProps
         ? AsPageProps<Omit<InertiaPages[Page], keyof SharedProps>>
         : never,
       viewProps?: Record<string, any>


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
There is a typescript error when we don't send some props with ``router.on('/mypage').renderInertia('mycomponent')``

```
TS2554: Expected 2-3 arguments, but got 1
inertia_provider.d.ts(32, 73): An argument for props was not provided.
```

This PR simply makes the “props” property optional in the inertia provider, as in previous versions.

Unless it's intentional?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
