### PR TITLE
Attempt to support nested Transformers

### DIFF
--- a/src/props.ts
+++ b/src/props.ts
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-import { BaseSerializer } from '@adonisjs/core/transformers'
+import { BaseSerializer, Collection, Item, Paginator } from '@adonisjs/core/transformers'
 import { type AsyncOrSync } from '@adonisjs/core/types/common'
 import { type JSONDataTypes } from '@adonisjs/core/types/transformers'
 
@@ -316,6 +316,13 @@ export function isOptionalProp<T extends UnPackedPageProps>(
 }
 
 /**
+ * Checks if a value is a transformer instance (Item, Collection, or Paginator).
+ */
+function isTransformerInstance(value: unknown): boolean {
+  return value instanceof Item || value instanceof Collection || value instanceof Paginator
+}
+
+/**
  * Helper function to unpack prop values using the transformer serialize function.
  *
  * @param value - The prop value to serialize
@@ -325,8 +332,20 @@ export function isOptionalProp<T extends UnPackedPageProps>(
 async function unpackPropValue(
   value: UnPackedPageProps<JSONDataTypes>,
   containerResolver: ContainerResolver<any>
-) {
-  return inertiaSerializer.serialize(value, containerResolver) as Promise<JSONDataTypes>
+): Promise<JSONDataTypes> {
+  if (isTransformerInstance(value)) {
+    return inertiaSerializer.serialize(value, containerResolver) as Promise<JSONDataTypes>
+  }
+
+  if (Array.isArray(value)) {
+    return Promise.all(value.map((item) => unpackPropValue(item, containerResolver)))
+  }
+
+  if (isObject(value)) {
+    return inertiaSerializer.serialize(value, containerResolver) as Promise<JSONDataTypes>
+  }
+
+  return value
 }
 
 /**
@@ -427,6 +446,15 @@ export async function buildStandardVisitProps(
 
       /**
        * Unpack all other values
+       */
+      unpackedValues.push({
+        key,
+        value: value,
+      })
+    } else if (Array.isArray(value)) {
+      /**
+       * Arrays may contain nested transformer instances
+       * that need to be resolved
        */
       unpackedValues.push({
         key,
@@ -567,6 +595,19 @@ export async function buildPartialRequestProps(
 
       /**
        * Unpack all other values
+       */
+      unpackedValues.push({ key, value: value as UnPackedPageProps })
+    } else if (Array.isArray(value)) {
+      /**
+       * Skip key if not part of cherry picking list
+       */
+      if (!cherryPickProps.includes(key)) {
+        continue
+      }
+
+      /**
+       * Arrays may contain nested transformer instances
+       * that need to be resolved
        */
       unpackedValues.push({ key, value: value as UnPackedPageProps })
     } else {

--- a/tests/inertia_page.spec.ts
+++ b/tests/inertia_page.spec.ts
@@ -1076,6 +1076,95 @@ test.group('Inertia.page | Transformers', () => {
     `)
   })
 
+  test('build page with nested component props using transformers', async ({ assert }) => {
+    type Props = {
+      user: {
+        id: number
+        timestamps: boolean
+      }
+      groups: [
+        {
+          post: { id: number; title: string }
+        },
+      ]
+      paginated: {
+        data: { id: number; title: string }[]
+        metadata: {
+          total: number
+        }
+      }
+    }
+
+    class PostsTransformer extends BaseTransformer<{ id: number; title: string }> {
+      toObject() {
+        return this.resource
+      }
+    }
+
+    class UserTransformer extends BaseTransformer<{ id: number; timestamps: boolean }> {
+      toObject() {
+        return this.resource
+      }
+    }
+
+    const inertia = new InertiaFactory<{
+      home: Props
+    }>().create()
+
+    const page = await inertia.page('home', {
+      user: UserTransformer.transform({
+        id: 1,
+        timestamps: true,
+      }),
+      groups: [
+        {
+          post: PostsTransformer.transform({ id: 1, title: 'Hello world' }),
+        },
+      ],
+      paginated: PostsTransformer.paginate([{ id: 1, title: 'Hello world' }], {
+        total: 10,
+      }),
+    })
+
+    assert.snapshot(page).matchInline(`
+      {
+        "clearHistory": false,
+        "component": "home",
+        "deepMergeProps": [],
+        "deferredProps": {},
+        "encryptHistory": false,
+        "mergeProps": [],
+        "props": {
+          "groups": [
+            {
+              "post": {
+                "id": 1,
+                "title": "Hello world",
+              },
+            },
+          ],
+          "paginated": {
+            "data": [
+              {
+                "id": 1,
+                "title": "Hello world",
+              },
+            ],
+            "metadata": {
+              "total": 10,
+            },
+          },
+          "user": {
+            "id": 1,
+            "timestamps": true,
+          },
+        },
+        "url": "",
+        "version": "1",
+      }
+    `)
+  })
+
   test('partial reload props using transformers', async ({ assert }) => {
     type Props = {
       user: {


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The serialization of Transformers used within an array that is part of the Inertia response props is not working as expected. The transferred JSON from the server to the client is a representation of the transformer, with `$type` and `data` attribute instead of the resolved resource.

I’ve added a test case and a sample implementation that would solve the issue with nested transformers in array response props. I’m seeing a TypeScript issue that I wasn’t able to solve. Maybe you have an idea how to approach it.


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [x] I have added a failing test for my reported issue.
