### PR TITLE
feat: allow returning null prop

### DIFF
--- a/src/props.ts
+++ b/src/props.ts
@@ -326,6 +326,7 @@ async function unpackPropValue(
   value: UnPackedPageProps<JSONDataTypes>,
   containerResolver: ContainerResolver<any>
 ) {
+  // Allow returning null values without serialization
   if (value === null) {
     return null
   }

--- a/src/props.ts
+++ b/src/props.ts
@@ -326,6 +326,9 @@ async function unpackPropValue(
   value: UnPackedPageProps<JSONDataTypes>,
   containerResolver: ContainerResolver<any>
 ) {
+  if (value === null) {
+    return null
+  }
   return inertiaSerializer.serialize(value, containerResolver) as Promise<JSONDataTypes>
 }
 

--- a/tests/inertia.spec.ts
+++ b/tests/inertia.spec.ts
@@ -311,6 +311,19 @@ test.group('Inertia', () => {
     assert.deepEqual(result.props, { foo: 'bar', baz: 'baz', qux: 'qux' })
   })
 
+  test('allow null values as props', async ({ assert }) => {
+    const inertia = new InertiaFactory().create()
+
+    const result: any = await inertia.render('foo', {
+      foo: null,
+      baz: () => null,
+      qux: async () => null,
+      always: inertia.always(null),
+    })
+
+    assert.deepEqual(result.props, { foo: null, baz: null, qux: null, always: null })
+  })
+
   test('return version in page object', async ({ assert }) => {
     const inertia = new InertiaFactory().withVersion('2').create()
     const result: any = await inertia.render('foo', {})


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)



### 📚 Description

Returning page props that have a `null` value will cause an error in the `serialize` method ([see here](https://github.com/adonisjs/http-transformers/blob/8961ad0c0b5c71241bc1d8f1ec9a07f7cd66cd5f/src/base_serializer.ts#L226)).

However, this use case can be useful when there is no resource. For example:

```ts
return ctx.inertia.render('api', {
  apiKey: async () => {
    const apiKey = await ApiKey.query().where('userId', ctx.auth.user.id).first()
    return apiKey ? ApiKeyTransformer.transform(apiKey) : null
  }
})
```

A workaround would be to return `undefined` instead of `null`, but in that case, the prop is not replaced in the view by Inertia since it is undefined.

Another solution would be to compute the result outside the callback, but it removes the benefits of partial reloads:

```ts
const apiKey = await ApiKey.query().where('userId', ctx.auth.user.id).first()

return ctx.inertia.render('api', {
  apiKey: apiKey ? ApiKeyTransformer.transform(apiKey) : null
})
```

This PR allows the `unpackPropValue` function to directly return a `null` value, bypassing the serializer.
I'm not sure if this is the right place to handle the escape case.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
