### PR TITLE
fix: do not execute deferred mergeable prop compute on standard visits

### DIFF
--- a/src/props.ts
+++ b/src/props.ts
@@ -75,6 +75,9 @@ export function defer<T extends UnPackedPageProps>(
     merge() {
       return merge(this)
     },
+    deepMerge() {
+      return deepMerge(this)
+    },
     [DEFERRED_PROP]: true,
   }
 }
@@ -411,16 +414,13 @@ export async function buildStandardVisitProps(
         if (isObject(value.value) && isDeferredProp(value.value)) {
           deferredProps[value.value.group] = deferredProps[value.value.group] ?? []
           deferredProps[value.value.group].push(key)
-          unpackedValues.push({
-            key,
-            value: value.value.compute,
-          })
-        } else {
-          unpackedValues.push({
-            key,
-            value: value.value,
-          })
+          continue
         }
+
+        unpackedValues.push({
+          key,
+          value: value.value,
+        })
 
         continue
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,8 @@ export type DeferProp<T extends UnPackedPageProps> = {
   compute: () => AsyncOrSync<T>
   /** Creates a mergeable version of this deferred prop */
   merge(): MergeableProp<DeferProp<T>>
+  /** Creates a deep-mergeable version of this deferred prop */
+  deepMerge(): MergeableProp<DeferProp<T>>
   /** Brand symbol to identify this as a deferred prop */
   [DEFERRED_PROP]: true
 }

--- a/tests/inertia.spec.ts
+++ b/tests/inertia.spec.ts
@@ -243,14 +243,91 @@ test.group('Inertia', () => {
   test('use mergeable and deferred props', async ({ assert }) => {
     const inertia = new InertiaFactory().create()
 
+    let computeCalls = 0
     const result: any = await inertia.render('foo', {
       foo: 'bar',
       baz: inertia.merge([1, 2, 3]),
-      bar: inertia.defer(() => 'bar').merge(),
+      bar: inertia
+        .defer(() => {
+          computeCalls++
+          return 'bar'
+        })
+        .merge(),
     })
 
     assert.deepEqual(result.deferredProps, { default: ['bar'] })
     assert.deepEqual(result.mergeProps, ['baz', 'bar'])
+    assert.deepEqual(result.deepMergeProps, [])
+    assert.deepEqual(result.props, { foo: 'bar', baz: [1, 2, 3] })
+    assert.equal(computeCalls, 0)
+  })
+
+  test('use deep-mergeable and deferred props via .deepMerge() chained on defer()', async ({
+    assert,
+  }) => {
+    const inertia = new InertiaFactory().create()
+
+    let computeCalls = 0
+    const result: any = await inertia.render('foo', {
+      foo: 'bar',
+      baz: inertia.deepMerge({ a: 1 }),
+      bar: inertia
+        .defer(() => {
+          computeCalls++
+          return { items: [1, 2, 3] }
+        })
+        .deepMerge(),
+    })
+
+    assert.deepEqual(result.deferredProps, { default: ['bar'] })
+    assert.deepEqual(result.mergeProps, [])
+    assert.deepEqual(result.deepMergeProps, ['baz', 'bar'])
+    assert.deepEqual(result.props, { foo: 'bar', baz: { a: 1 } })
+    assert.equal(computeCalls, 0)
+  })
+
+  test('use deep-mergeable and deferred props via inertia.deepMerge(inertia.defer())', async ({
+    assert,
+  }) => {
+    const inertia = new InertiaFactory().create()
+
+    let computeCalls = 0
+    const result: any = await inertia.render('foo', {
+      foo: 'bar',
+      bar: inertia.deepMerge(
+        inertia.defer(() => {
+          computeCalls++
+          return { items: [1, 2, 3] }
+        })
+      ),
+    })
+
+    assert.deepEqual(result.deferredProps, { default: ['bar'] })
+    assert.deepEqual(result.deepMergeProps, ['bar'])
+    assert.deepEqual(result.mergeProps, [])
+    assert.deepEqual(result.props, { foo: 'bar' })
+    assert.equal(computeCalls, 0)
+  })
+
+  test('load mergeable deferred props when present in x-inertia-partial-data', async ({
+    assert,
+  }) => {
+    const inertia = new InertiaFactory().partialReload('foo').only(['bar']).create()
+
+    let computeCalls = 0
+    const result: any = await inertia.render('foo', {
+      foo: 'bar',
+      bar: inertia
+        .defer(() => {
+          computeCalls++
+          return { items: [1, 2, 3] }
+        })
+        .deepMerge(),
+    })
+
+    assert.deepEqual(result.props, { bar: { items: [1, 2, 3] } })
+    assert.deepEqual(result.deepMergeProps, ['bar'])
+    assert.equal(computeCalls, 1)
   })
 
   test('properly handle null and undefined values on first visit', async ({ assert }) => {

--- a/tests/inertia_page.spec.ts
+++ b/tests/inertia_page.spec.ts
@@ -906,25 +906,12 @@ test.group('Inertia.page', () => {
           "paginated",
         ],
         "props": {
-          "paginated": {
-            "data": [
-              {
-                "id": 1,
-                "title": "Hello world",
-              },
-            ],
-            "total": 10,
-          },
           "posts": [
             {
               "id": 1,
               "title": "Hello world",
             },
           ],
-          "user": {
-            "id": 1,
-            "timestamps": true,
-          },
         },
         "url": "",
         "version": "1",
@@ -1949,27 +1936,12 @@ test.group('Inertia.page | Transformers', () => {
           "paginated",
         ],
         "props": {
-          "paginated": {
-            "data": [
-              {
-                "id": 1,
-                "title": "Hello world",
-              },
-            ],
-            "metadata": {
-              "total": 10,
-            },
-          },
           "posts": [
             {
               "id": 1,
               "title": "Hello world",
             },
           ],
-          "user": {
-            "id": 1,
-            "timestamps": true,
-          },
         },
         "url": "",
         "version": "1",


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

Resolves #90

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes #90 by addressing two related problems in mergeable + deferred props:

**1. Bug fix — `buildStandardVisitProps` was running the compute on standard visits**

In `src/props.ts` (`buildStandardVisitProps`), the mergeable-wrapping-deferred branch had a comment that promised "Mergeable deferred props are skipped during the standard visits" but the code violated that comment by pushing `value.value.compute` into `unpackedValues`, which is then `await`ed and stored into `newProps[key]` at the bottom of the function.

As a consequence, for any prop declared as `inertia.defer(fn).merge()`, `inertia.defer(fn).deepMerge()`, or `inertia.deepMerge(inertia.defer(fn))`:

1. The `compute` ran synchronously during the initial render.
2. The resolved value was sent inside `props` **and** the prop name was registered inside `deferredProps`.
3. The client saw the prop in `deferredProps` and dispatched a partial reload for the same prop. With `preserveUrl`, that partial reload hit the same URL, re-ran the same compute, and the response was merged with the value already present in `props`.

The user-visible symptom in a real app was duplicated rows on first paint of an infinite-scroll list using `WhenVisible` + `deepMerge` (`React: Encountered two children with the same key`) and the compute being executed twice per visit.

This PR makes that branch `continue` early (matching the comment and matching what the plain deferred branch above already does). `buildPartialRequestProps` already handled this correctly — no change needed there.

**2. New feature — `deepMerge()` chained method on `defer()`**

The official docs at https://docs.adonisjs.com/guides/frontend/inertia#mergeable-props show `inertia.defer(fn).deepMerge()` as the chainable API:

```ts
return inertia.render('users/index', {
  notifications: inertia.defer(() => fetchNotifications()).deepMerge(),
})
```

…but `DeferProp` did not expose `deepMerge()` in runtime or in types — only `.merge()` existed. Calling the documented `.defer().deepMerge()` threw `TypeError: deepMerge is not a function`. This PR adds the method (mirroring the existing `merge()`) and the matching type entry, so the documented API works.

### What changed

- `src/props.ts` — `defer()` now returns an object with a `deepMerge()` method in addition to `merge()`.
- `src/props.ts` — `buildStandardVisitProps` no longer pushes the deferred compute into `unpackedValues` when the prop is mergeable + deferred; it `continue`s instead, matching the existing inline comment and the behavior of the plain deferred branch above.
- `src/types.ts` — `DeferProp` type now includes `deepMerge(): MergeableProp<DeferProp<T>>`.

### Tests

All 175 tests pass (172 baseline + 3 new), lint and typecheck are clean.

- `tests/inertia.spec.ts` — tightened the existing `"use mergeable and deferred props"` test to assert that the `compute` is **not called** on the standard visit and that the deferred value is **not present** in `props`. This is what would have caught the bug originally.
- `tests/inertia.spec.ts` — added 3 new tests:
  - `"use deep-mergeable and deferred props via .deepMerge() chained on defer()"` — covers the newly exposed chained API.
  - `"use deep-mergeable and deferred props via inertia.deepMerge(inertia.defer())"` — covers the equivalent wrapped form.
  - `"load mergeable deferred props when present in x-inertia-partial-data"` — ensures `buildPartialRequestProps` still runs the compute on the partial reload (the path that was already correct).
- `tests/inertia_page.spec.ts` — updated 2 inline snapshots (`"build page with optional props via mergeable and defer helper"` and its transformers counterpart). The previous snapshots were baking in the buggy behavior (the deferred-mergeable values appeared inside `props` on the standard visit). After the fix they correctly omit those values from `props` and keep them only in `deferredProps`.

### Backwards compatibility

- For users of `defer().merge()` / `inertia.merge(inertia.defer(...))` who were relying on the (incorrect) initial value being present in `props`: those users were already getting a duplicate fetch + a duplicate merge. The new behavior matches what `defer` is documented to do (skipped on standard visits, fetched on partial reload).
- `.deepMerge()` chained on `defer()` is additive — no existing API changes.
- No public type signatures are removed.

### 📝 Checklist

- [x] I have linked an issue or discussion. (#90)
- [ ] I have updated the documentation accordingly.

> The docs page at https://docs.adonisjs.com/guides/frontend/inertia#mergeable-props already documents `inertia.defer(fn).deepMerge()` (which this PR makes actually work), so no doc change is needed for the new feature. If maintainers prefer a small note about the bug fix on that page, I can open a follow-up PR on the docs repo.
