### PR TITLE
fix(props): honor X-Inertia-Reset header in partial reload builder

### DIFF
--- a/src/inertia.ts
+++ b/src/inertia.ts
@@ -254,7 +254,12 @@ export class Inertia<Pages> {
       debug('building props for a partial reload %O', requestInfo)
       debug('cherry picking props %s', cherryPickProps)
 
-      return buildPartialRequestProps(finalProps, cherryPickProps, this.ctx.containerResolver)
+      return buildPartialRequestProps(
+        finalProps,
+        cherryPickProps,
+        this.ctx.containerResolver,
+        requestInfo.resetProps ?? []
+      )
     }
 
     debug('building props for a standard visit %O', requestInfo)

--- a/src/props.ts
+++ b/src/props.ts
@@ -485,6 +485,10 @@ export async function buildStandardVisitProps(
  * @param pageProps - The page props to process
  * @param cherryPickProps - Array of prop names to include
  * @param containerResolver - Container resolver for dependency injection
+ * @param resetProps - Array of prop names the client asked to reset via the
+ *   `X-Inertia-Reset` header. Keys present in this list are excluded from the
+ *   returned `mergeProps`/`deepMergeProps` so the client replaces the value
+ *   instead of merging/concatenating with the previous value.
  * @returns Promise resolving to object containing processed props and merge props list
  *
  * @example
@@ -499,7 +503,8 @@ export async function buildStandardVisitProps(
 export async function buildPartialRequestProps(
   pageProps: PageProps,
   cherryPickProps: string[],
-  containerResolver: ContainerResolver<any>
+  containerResolver: ContainerResolver<any>,
+  resetProps: string[] = []
 ) {
   const mergeProps: string[] = []
   const deepMergeProps: string[] = []
@@ -607,8 +612,8 @@ export async function buildPartialRequestProps(
 
   return {
     props: newProps,
-    mergeProps,
-    deepMergeProps,
+    mergeProps: mergeProps.filter((key) => !resetProps.includes(key)),
+    deepMergeProps: deepMergeProps.filter((key) => !resetProps.includes(key)),
     deferredProps: {},
   }
 }

--- a/tests/inertia.spec.ts
+++ b/tests/inertia.spec.ts
@@ -253,6 +253,70 @@ test.group('Inertia', () => {
     assert.deepEqual(result.mergeProps, ['baz', 'bar'])
   })
 
+  test('reset header excludes keys from mergeProps on partial reload', async ({ assert }) => {
+    const inertia = new InertiaFactory()
+      .partialReload('foo')
+      .only(['posts', 'stats'])
+      .reset(['posts'])
+      .create()
+
+    const result: any = await inertia.render('foo', {
+      posts: inertia.merge([1, 2, 3]),
+      stats: inertia.merge({ total: 10 }),
+    })
+
+    assert.deepEqual(result.props, { posts: [1, 2, 3], stats: { total: 10 } })
+    assert.deepEqual(result.mergeProps, ['stats'])
+    assert.deepEqual(result.deepMergeProps, [])
+  })
+
+  test('reset header excludes keys from deepMergeProps on partial reload', async ({ assert }) => {
+    const inertia = new InertiaFactory()
+      .partialReload('foo')
+      .only(['posts', 'stats'])
+      .reset(['posts'])
+      .create()
+
+    const result: any = await inertia.render('foo', {
+      posts: inertia.deepMerge({ items: [1, 2, 3] }),
+      stats: inertia.deepMerge({ total: 10 }),
+    })
+
+    assert.deepEqual(result.props, { posts: { items: [1, 2, 3] }, stats: { total: 10 } })
+    assert.deepEqual(result.deepMergeProps, ['stats'])
+    assert.deepEqual(result.mergeProps, [])
+  })
+
+  test('reset header excludes deferred mergeable keys from deepMergeProps', async ({ assert }) => {
+    const inertia = new InertiaFactory()
+      .partialReload('foo')
+      .only(['cards'])
+      .reset(['cards'])
+      .create()
+
+    const result: any = await inertia.render('foo', {
+      cards: inertia.deepMerge(inertia.defer(() => ({ items: ['a', 'b'] }))),
+    })
+
+    assert.deepEqual(result.props, { cards: { items: ['a', 'b'] } })
+    assert.deepEqual(result.deepMergeProps, [])
+    assert.deepEqual(result.mergeProps, [])
+  })
+
+  test('omitting reset header preserves mergeProps/deepMergeProps as before', async ({
+    assert,
+  }) => {
+    const inertia = new InertiaFactory().partialReload('foo').only(['posts', 'stats']).create()
+
+    const result: any = await inertia.render('foo', {
+      posts: inertia.merge([1, 2, 3]),
+      stats: inertia.deepMerge({ total: 10 }),
+    })
+
+    assert.deepEqual(result.mergeProps, ['posts'])
+    assert.deepEqual(result.deepMergeProps, ['stats'])
+  })
+
   test('properly handle null and undefined values on first visit', async ({ assert }) => {
     setupViewMacroMock()
 


### PR DESCRIPTION
The `X-Inertia-Reset` header was parsed into `requestInfo.resetProps` but never applied when building the response. As a result, props configured with `inertia.defer(fn).deepMerge()` (or `.merge()`) would always be returned with their key in `mergeProps`/`deepMergeProps`, causing the Inertia client to concatenate arrays (or deep merge objects) even when the client explicitly requested a reset via
`router.visit({ reset: ['key'] })`.

This change makes `buildPartialRequestProps` accept the resolved `resetProps` list and exclude those keys from the returned `mergeProps`/`deepMergeProps` arrays. The client then performs a standard replace instead of an append/deep-merge for the reset keys, restoring the expected behavior for infinite-scroll filter changes and any other reset scenario.

Tests:
- tests/inertia.spec.ts: 4 new tests covering reset on mergeProps, reset on deepMergeProps, reset on a deferred mergeable prop, and a regression test confirming that omitting the reset header leaves mergeProps/deepMergeProps unchanged.

<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `X-Inertia-Reset` header sent by the Inertia client (e.g. via `router.visit(url, { reset: ['posts'] })`) is currently parsed by the server into `requestInfo.resetProps` (`src/inertia.ts`), but the value is never applied when building the partial response. As a result, keys that were registered as `merge`/`deepMerge` on the server **always** come back inside `mergeProps`/`deepMergeProps`, and the Inertia client keeps appending/deep-merging incoming data into the previous array, even when the developer explicitly asked for a reset.

This is most visible in infinite-scroll patterns where filtering is layered on top of pagination — a very common pattern in AdonisJS apps:

```ts
// controller
return inertia.render('posts/index', {
  posts: inertia.defer(() => listPosts(filters)).deepMerge(),
})

// page
function handleFilterChange(value: string) {
  router.visit('/posts', {
    qs: { filter: value },
    only: ['posts'],
    reset: ['posts'], // 👈 expected to clear the merged buffer, but is ignored today
  })
}
```
Today, every filter change concatenates the newly-fetched page on top of the previously accumulated pages, producing duplicate items (and, in React, the well-known "Encountered two children with the same key" warning).

#### What this PR does

• Makes buildPartialRequestProps accept an optional resetProps: string[] = [] parameter (src/props.ts).
• Filters the returned mergeProps and deepMergeProps arrays to exclude any key listed in resetProps, so the client falls back to standard prop replacement for those keys.
• Wires the parameter from Inertia#buildPageProps (src/inertia.ts), passing requestInfo.resetProps ?? [].
• JSDoc updated on buildPartialRequestProps describing the new parameter.

#### Backward compatibility

The new parameter is optional with an empty-array default, so the behavior of any request that does not send X-Inertia-Reset is byte-for-byte identical to today's. No public API changes; no breaking changes.

#### Test coverage

Four new tests added to tests/inertia.spec.ts:

• reset header excludes keys from mergeProps on partial reload
• reset header excludes keys from deepMergeProps on partial reload
• reset header excludes deferred mergeable keys from deepMergeProps
• omitting reset header preserves mergeProps/deepMergeProps as before (regression)

All four assert on props, mergeProps, and deepMergeProps from the response. The full suite (npm run quick:test) passes locally: 176 passed, 4 skipped.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.