### PR TITLE
Constrain resolvePageComponent generic to match module shape

### DIFF
--- a/src/client/helpers.ts
+++ b/src/client/helpers.ts
@@ -33,11 +33,11 @@
  *
  * @throws Error When none of the provided paths can be resolved in the pages registry
  */
-export async function resolvePageComponent<T>(
+export async function resolvePageComponent<T extends { default: unknown }>(
   path: string | string[],
   pages: Record<string, Promise<T> | (() => Promise<T>) | T>,
   layout?: any
-): Promise<T> {
+): Promise<T['default']> {
   for (const p of Array.isArray(path) ? path : [path]) {
     const page = pages[p]
     if (typeof page === 'undefined') {


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

`resolvePageComponent` always receives and returns a full ES module (`{ default: TComponent }`). It explicitly validates and manipulates `.default`, but the unconstrained generic `T` created a type mismatch.

This PR contrains `T` to reflect what the function requires:
```diff
- export async function resolvePageComponent<T>(
+ export async function resolvePageComponent<T extends { default: unknown }>(
  path: string | string[],
  pages: Record<string, Promise<T> | (() => Promise<T>) | T>,
  layout?: any
- ): Promise<T> {
+ ): Promise<T['default']> {
```

If you use `import.meta.glob`, you may now pass `ComponentType` to it to get the right type.
```ts
import type { type ComponentType } from 'react'
createInertiaApp({
// (...)
resolve: (name) => {
    return resolvePageComponent(
      `./pages/${name}.tsx`,
      import.meta.glob<ComponentType>('./pages/**/*.tsx')
    )
  },
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
