### PR TITLE
feat: make the Inertia class macroable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
+        "@poppinss/macroable": "^1.1.2",
         "@poppinss/utils": "^7.0.0",
         "edge-error": "^4.0.2",
         "html-entities": "^2.6.0"
@@ -43,7 +44,7 @@
         "edge.js": "^6.5.0",
         "eslint": "^10.0.2",
         "get-port": "^7.1.0",
-        "prettier": "^3.8.1",
+        "prettier": "^3.9.5",
         "react": "^19.2.4",
         "release-it": "^19.2.4",
         "supertest": "^7.2.2",
@@ -127,7 +128,6 @@
       "version": "9.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/hooks": "^7.3.0",
         "@poppinss/macroable": "^1.1.0",
@@ -153,7 +153,6 @@
       "version": "8.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adonisjs/env": "^7.0.0",
         "@antfu/install-pkg": "^1.1.0",
@@ -210,7 +209,6 @@
       "version": "6.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/utils": "^7.0.0"
       },
@@ -222,7 +220,6 @@
       "version": "7.3.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adonisjs/ace": "^14.1.0",
         "@adonisjs/application": "^9.0.0",
@@ -366,7 +363,6 @@
       "version": "11.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/utils": "^7.0.0",
         "parse-imports": "^3.0.0"
@@ -415,7 +411,6 @@
       "version": "8.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/macroable": "^1.1.2",
         "@poppinss/matchit": "^3.2.0",
@@ -483,7 +478,6 @@
       "version": "7.1.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/utils": "^7.0.0",
         "abstract-logging": "^2.0.1",
@@ -902,7 +896,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/utils": "^7.0.0-next.7"
       },
@@ -988,11 +981,39 @@
         }
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1996,7 +2017,6 @@
       "version": "3.2.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/hooks": "^7.3.0",
         "@poppinss/macroable": "^1.1.0",
@@ -2032,7 +2052,6 @@
       "version": "4.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/macroable": "^1.1.0",
         "@types/chai": "^5.2.3",
@@ -2110,7 +2129,6 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.16.0"
       },
@@ -2137,7 +2155,6 @@
       "version": "5.3.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@japa/core": "^10.4.0",
         "@japa/errors-printer": "^4.1.4",
@@ -2350,7 +2367,6 @@
       "version": "7.0.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2598,7 +2614,6 @@
     },
     "node_modules/@poppinss/macroable": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@poppinss/matchit": {
@@ -3937,7 +3952,6 @@
       "version": "8.59.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -4296,7 +4310,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4551,7 +4564,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5688,7 +5700,6 @@
       "version": "6.5.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/inspect": "^1.0.1",
         "@poppinss/macroable": "^1.1.0",
@@ -5938,7 +5949,6 @@
       "version": "10.3.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5993,7 +6003,6 @@
       "version": "10.1.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7510,7 +7519,6 @@
       "version": "2.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -8647,10 +8655,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8903,7 +8912,6 @@
       "version": "19.2.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9075,7 +9083,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nodeutils/defaults-deep": "1.1.0",
         "@octokit/rest": "22.0.1",
@@ -9225,7 +9232,6 @@
       "version": "1.0.0-rc.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.112.0",
         "@rolldown/pluginutils": "1.0.0-rc.3"
@@ -9432,7 +9438,8 @@
     "node_modules/scheduler": {
       "version": "0.27.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.8.0",
@@ -10241,7 +10248,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10366,6 +10372,40 @@
         "synckit": {
           "optional": true
         }
+      }
+    },
+    "node_modules/unrun/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/unrun/node_modules/@oxc-project/types": {
@@ -10728,7 +10768,6 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10818,7 +10857,6 @@
       "version": "3.5.34",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.34",
         "@vue/compiler-sfc": "3.5.34",
@@ -11170,7 +11208,6 @@
       "version": "4.1.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/colors": "^4.1.6",
         "@poppinss/dumper": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "vue": "^3.5.29"
   },
   "dependencies": {
+    "@poppinss/macroable": "^1.1.2",
     "@poppinss/utils": "^7.0.0",
     "edge-error": "^4.0.2",
     "html-entities": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "edge.js": "^6.5.0",
     "eslint": "^10.0.2",
     "get-port": "^7.1.0",
-    "prettier": "^3.8.1",
+    "prettier": "^3.9.5",
     "react": "^19.2.4",
     "release-it": "^19.2.4",
     "supertest": "^7.2.2",

--- a/src/client/react/form.tsx
+++ b/src/client/react/form.tsx
@@ -39,8 +39,7 @@ export type FormActionProps = Omit<React.ComponentPropsWithoutRef<typeof Inertia
  * Union type for Form component props - either route-based or direct action
  */
 export type FormProps<Route extends keyof Routes = keyof Routes> =
-  | FormRouteProps<Route>
-  | FormActionProps
+  FormRouteProps<Route> | FormActionProps
 
 /**
  * Internal Form component implementation with forward ref support.

--- a/src/client/react/link.tsx
+++ b/src/client/react/link.tsx
@@ -39,8 +39,7 @@ export type LinkHrefProps = Omit<React.ComponentPropsWithoutRef<typeof InertiaLi
  * Union type for Link component props - either route-based or direct href
  */
 export type LinkProps<Route extends keyof Routes = keyof Routes> =
-  | LinkRouteProps<Route>
-  | LinkHrefProps
+  LinkRouteProps<Route> | LinkHrefProps
 
 /**
  * Internal Link component implementation with forward ref support.

--- a/src/client/react/router.ts
+++ b/src/client/react/router.ts
@@ -32,8 +32,7 @@ type VisitHrefParams = {
  * Union type for visit parameters - either route-based or direct href
  */
 type VisitParams<Route extends keyof InferRoutes<UserRegistry> = keyof InferRoutes<UserRegistry>> =
-  | VisitRouteParams<Route>
-  | VisitHrefParams
+  VisitRouteParams<Route> | VisitHrefParams
 
 /**
  * Custom hook providing type-safe navigation utilities for Inertia.js.

--- a/src/client/vue/router.ts
+++ b/src/client/vue/router.ts
@@ -32,8 +32,7 @@ type VisitHrefParams = {
  * Union type for visit parameters - either route-based or direct href
  */
 type VisitParams<Route extends keyof InferRoutes<UserRegistry> = keyof InferRoutes<UserRegistry>> =
-  | VisitRouteParams<Route>
-  | VisitHrefParams
+  VisitRouteParams<Route> | VisitHrefParams
 
 /**
  * Composable providing type-safe navigation utilities for Inertia.js.

--- a/src/inertia.ts
+++ b/src/inertia.ts
@@ -34,6 +34,7 @@ import {
   buildStandardVisitProps,
   buildPartialRequestProps,
 } from './props.ts'
+import Macroable from '@poppinss/macroable'
 import debug from './debug.ts'
 import { type AsyncOrSync } from '@poppinss/utils/types'
 
@@ -57,7 +58,7 @@ import { type AsyncOrSync } from '@poppinss/utils/types'
  * inertia.location('/dashboard')
  * ```
  */
-export class Inertia<Pages> {
+export class Inertia<Pages> extends Macroable {
   #sharedStateProviders?: (PageProps | (() => AsyncOrSync<PageProps>))[]
   #cachedRequestInfo?: RequestInfo
 
@@ -168,6 +169,7 @@ export class Inertia<Pages> {
     vite?: Vite,
     serverRenderer?: ServerRenderer
   ) {
+    super()
     if (debug.enabled) {
       debug(
         'instantiating inertia instance for request "%s" using config %O',

--- a/src/inertia_middleware.ts
+++ b/src/inertia_middleware.ts
@@ -11,7 +11,7 @@
 
 import type { HttpContext } from '@adonisjs/core/http'
 
-import { type Inertia } from './inertia.js'
+import type { Inertia } from '../index.ts'
 import { InertiaHeaders } from './headers.js'
 import { InertiaManager } from './inertia_manager.ts'
 import type { ComponentProps, InertiaPages, PageProps } from './types.js'
@@ -19,6 +19,15 @@ import debug from './debug.ts'
 
 declare module '@adonisjs/core/http' {
   export interface HttpContext {
+    /**
+     * The Inertia instance for the current HTTP request
+     *
+     * The type must be referenced from the package entrypoint, so that every
+     * program type-checking `ctx.inertia` also loads the entrypoint
+     * declarations. Otherwise, augmenting the class via
+     * `declare module '@adonisjs/inertia'` fails in programs that never
+     * import the entrypoint themselves.
+     */
     inertia: Inertia<InertiaPages>
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,8 +183,7 @@ type PagePropsEagerDataTypes<T extends JSONDataTypes> =
  * @template T - The data type extending JSONDataTypes, defaults to JSONDataTypes
  */
 export type PagePropsDataTypes<T extends JSONDataTypes = JSONDataTypes> =
-  | PagePropsEagerDataTypes<T>
-  | PagePropsLazyDataTypes<T>
+  PagePropsEagerDataTypes<T> | PagePropsLazyDataTypes<T>
 
 /**
  * Record type representing all page props that can be passed to an Inertia page
@@ -298,15 +297,19 @@ export type ToComponentProps<Props extends PageProps> = Prettify<
  */
 export type AsPageProps<Props extends ComponentProps> = Prettify<
   {
-    [K in {
-      [O in keyof Props]: [undefined] extends [Props[O]] ? O : never
-    }[keyof Props]]?:
+    [
+      K in {
+        [O in keyof Props]: [undefined] extends [Props[O]] ? O : never
+      }[keyof Props]
+    ]?:
       | PagePropsDataTypes<Props[K]>
       | MergeableProp<UnPackedPageProps<Props[K]> | DeferProp<UnPackedPageProps<Props[K]>>>
   } & {
-    [K in {
-      [O in keyof Props]: [undefined] extends [Props[O]] ? never : O
-    }[keyof Props]]: PagePropsEagerDataTypes<Props[K]> | MergeableProp<UnPackedPageProps<Props[K]>>
+    [
+      K in {
+        [O in keyof Props]: [undefined] extends [Props[O]] ? never : O
+      }[keyof Props]
+    ]: PagePropsEagerDataTypes<Props[K]> | MergeableProp<UnPackedPageProps<Props[K]>>
   }
 >
 

--- a/tests/inertia.spec.ts
+++ b/tests/inertia.spec.ts
@@ -13,6 +13,7 @@ import { Vite } from '@adonisjs/vite'
 import { HttpContext } from '@adonisjs/core/http'
 import { HttpContextFactory, RequestFactory } from '@adonisjs/core/factories/http'
 
+import { Inertia } from '../src/inertia.ts'
 import { InertiaHeaders } from '../src/headers.ts'
 import { setupViewMacroMock, setupVite } from './helpers.js'
 import { InertiaFactory } from '../factories/inertia_factory.js'
@@ -20,6 +21,16 @@ import { ServerRenderer } from '../src/server_renderer.js'
 import { defineConfig } from '../src/define_config.js'
 
 test.group('Inertia', () => {
+  test('is macroable so packages can extend it', ({ assert }) => {
+    Inertia.macro('greet' as any, function (this: Inertia<any>) {
+      return `hello from ${this.constructor.name}`
+    })
+
+    const inertia = new InertiaFactory().create()
+
+    assert.equal((inertia as any).greet(), 'hello from Inertia')
+  })
+
   test('Set X-Inertia-Location header with 409 status code', async ({ assert }) => {
     const ctx = new HttpContextFactory().create()
     const inertia = new InertiaFactory().merge({ ctx }).create()


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

Resolves the feature request discussed in adonisjs/core#5121.

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Makes the `Inertia` class extensible through the standard AdonisJS extension
pattern, in two parts:

**1. Make `Inertia` extend `Macroable`**

Packages can register methods with `Inertia.macro()` / `Inertia.getter()`
instead of patching `Inertia.prototype` — same pattern as `Request`,
`Response`, `BriskRoute`, etc. `@poppinss/macroable` is added as a dependency
(already used across AdonisJS core packages).

**2. Type `ctx.inertia` against the package entrypoint**

The `HttpContext` augmentation in `inertia_middleware.ts` now imports the
`Inertia` type from the package entrypoint instead of the internal module
path. Without this, a third-party `declare module '@adonisjs/inertia'`
augmentation silently no-ops in TS programs that never import the entrypoint
themselves (e.g. a Tuyau client tsconfig that pulls controllers in through the
generated registry):

error TS2664: Invalid module name in augmentation, module '@adonisjs/inertia' cannot be found.
error TS2339: Property 'modal' does not exist on type 'Inertia<InertiaPages>'.

With the entrypoint import, any program that type-checks `ctx.inertia` also
loads the entrypoint declarations, so the interface → class merge always
attaches. The import is type-only, so the compiled middleware gains no runtime
import.

**Real-world validation**

I migrated [adonis-inertia-modal](https://github.com/filipebraida/adonis-inertia-modal)
to this branch — diff:
[`main...feat/inertia-macroable`](https://github.com/filipebraida/adonis-inertia-modal/compare/main...feat/inertia-macroable)

- The provider now registers `modal()` via `Inertia.macro()`; the package's
  test suite (116 tests, provider booted for real) passes against this branch.
- The type augmentation workaround (force-loading the barrel with a type-only
  import kept alive by a dummy marker export) is deleted entirely, and both
  the server tsconfig and the Tuyau-style client tsconfig of a real app
  type-check `inertia.modal(...)` correctly.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.