### PR TITLE
Preserve route body types in Form

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
   "scripts": {
     "pretest": "npm run lint",
     "test": "npm run quick:test",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "npm run typecheck:node && npm run typecheck:react && npm run typecheck:vue",
+    "typecheck:node": "tsc --noEmit",
+    "typecheck:react": "tsc --noEmit -p tests/types/tsconfig.react.json",
+    "typecheck:vue": "vue-tsc --noEmit -p tests/types/tsconfig.vue.json",
     "clean": "del-cli build",
     "compile": "tsdown && tsc --emitDeclarationOnly --declaration",
     "copy:templates": "copyfiles \"stubs/**/*.stub\" build",
@@ -83,7 +86,8 @@
     "tsdown": "^0.22.7",
     "typescript": "~6.0.3",
     "vite": "^8.1.4",
-    "vue": "^3.5.39"
+    "vue": "^3.5.39",
+    "vue-tsc": "~3.2.0"
   },
   "dependencies": {
     "@poppinss/utils": "^7.0.1",

--- a/src/client/common.ts
+++ b/src/client/common.ts
@@ -13,6 +13,14 @@ import type { AreAllOptional } from '@poppinss/utils/types'
 export type Routes = InferRoutes<UserRegistry>
 
 /**
+ * Get request body type for a route
+ */
+export type ExtractRouteBody<Route extends keyof Routes> =
+  Routes[Route]['types']['body'] extends object
+    ? Routes[Route]['types']['body']
+    : Record<string, never>
+
+/**
  * Get parameter tuple type for a route
  */
 export type ExtractParamsTuple<Route extends keyof Routes> = Routes[Route]['types']['paramsTuple']

--- a/src/client/react/form.tsx
+++ b/src/client/react/form.tsx
@@ -9,8 +9,21 @@
 
 import React from 'react'
 import { Form as InertiaForm } from '@inertiajs/react'
+// Inertia's declarations omit NodeNext-compatible extensions from internal type re-exports.
+// @ts-ignore TypeScript resolves these exports correctly in client projects using Bundler resolution.
+import type { FormComponentProps, FormComponentRef, FormComponentSlotProps } from '@inertiajs/core'
 import { useTuyau } from './context.tsx'
-import type { RouteParams, Routes } from '../common.ts'
+import type { ExtractRouteBody, RouteParams, Routes } from '../common.ts'
+
+const BaseForm = InertiaForm as any
+
+type InertiaFormProps<FormData extends object> = FormComponentProps<FormData> &
+  Omit<React.FormHTMLAttributes<HTMLFormElement>, keyof FormComponentProps | 'children'> &
+  Omit<React.AllHTMLAttributes<HTMLFormElement>, keyof FormComponentProps | 'children'> & {
+    children?: React.ReactNode | ((props: FormComponentSlotProps<FormData>) => React.ReactNode)
+  }
+
+export type FormRef<FormData extends object> = FormComponentRef<FormData>
 
 /**
  * Parameters required for route navigation with proper type safety.
@@ -21,7 +34,7 @@ export type FormParams<Route extends keyof Routes> = RouteParams<Route>
  * Props for the Form component when using route-based navigation
  */
 export type FormRouteProps<Route extends keyof Routes> = Omit<
-  React.ComponentPropsWithoutRef<typeof InertiaForm>,
+  InertiaFormProps<ExtractRouteBody<Route>>,
   'action' | 'method'
 > &
   FormParams<Route> & {
@@ -31,15 +44,20 @@ export type FormRouteProps<Route extends keyof Routes> = Omit<
 /**
  * Props for the Form component when using direct action
  */
-export type FormActionProps = Omit<React.ComponentPropsWithoutRef<typeof InertiaForm>, 'route'> & {
+export type FormActionProps<FormData extends object = Record<string, any>> = Omit<
+  InertiaFormProps<FormData>,
+  'route'
+> & {
   route?: never
 }
 
 /**
  * Union type for Form component props - either route-based or direct action
  */
-export type FormProps<Route extends keyof Routes = keyof Routes> =
-  FormRouteProps<Route> | FormActionProps
+export type FormProps<
+  Route extends keyof Routes = keyof Routes,
+  FormData extends object = Record<string, any>,
+> = FormRouteProps<Route> | FormActionProps<FormData>
 
 /**
  * Internal Form component implementation with forward ref support.
@@ -47,15 +65,18 @@ export type FormProps<Route extends keyof Routes = keyof Routes> =
  * for Inertia form submission when using route-based navigation.
  * Falls back to standard InertiaForm when action is provided directly.
  */
-function FormInner<Route extends keyof Routes>(
-  props: FormProps<Route>,
-  ref?: React.ForwardedRef<React.ElementRef<typeof InertiaForm>>
+function FormInner<
+  Route extends keyof Routes = keyof Routes,
+  FormData extends object = Record<string, any>,
+>(
+  props: FormProps<Route, FormData>,
+  ref?: React.ForwardedRef<FormRef<ExtractRouteBody<Route>> | FormRef<FormData>>
 ) {
   const tuyau = useTuyau()
 
   // Check if props has action (direct form submission)
   if ('action' in props) {
-    return <InertiaForm {...props} ref={ref} />
+    return <BaseForm {...props} ref={ref} />
   }
 
   // Route-based navigation
@@ -63,7 +84,7 @@ function FormInner<Route extends keyof Routes>(
   const routeInfo = tuyau.getRoute((props as any).route, { params })
 
   return (
-    <InertiaForm
+    <BaseForm
       {...formProps}
       action={{ url: routeInfo.url, method: routeInfo.methods[0].toLowerCase() as any }}
       ref={ref}
@@ -113,8 +134,27 @@ function FormInner<Route extends keyof Routes>(
  * </Form>
  * ```
  */
-export const Form: <Route extends keyof Routes>(
-  props: FormProps<Route> & {
-    ref?: React.Ref<React.ElementRef<typeof InertiaForm>>
-  }
-) => ReturnType<typeof FormInner> = React.forwardRef(FormInner as any) as any
+export const Form: {
+  <Route extends keyof Routes>(
+    props: FormRouteProps<Route> & {
+      ref?: React.Ref<FormRef<ExtractRouteBody<Route>>>
+    }
+  ): ReturnType<typeof FormInner>
+  <FormData extends object = Record<string, any>>(
+    props: FormActionProps<FormData> & {
+      ref?: React.Ref<FormRef<FormData>>
+    }
+  ): ReturnType<typeof FormInner>
+  /**
+   * Combined signature used by component helpers such as React.createElement.
+   */
+  <Route extends keyof Routes, FormData extends object = Record<string, any>>(
+    props:
+      | (FormRouteProps<Route> & {
+          ref?: React.Ref<FormRef<ExtractRouteBody<Route>>>
+        })
+      | (FormActionProps<FormData> & {
+          ref?: React.Ref<FormRef<FormData>>
+        })
+  ): ReturnType<typeof FormInner>
+} = React.forwardRef(FormInner as any) as any

--- a/src/client/vue/form.ts
+++ b/src/client/vue/form.ts
@@ -8,22 +8,81 @@
  */
 
 import { defineComponent, h } from 'vue'
-import type { PropType, SlotsType } from 'vue'
+import type { PropType, PublicProps, VNode } from 'vue'
 import { Form as InertiaForm } from '@inertiajs/vue3'
+// Inertia's declarations omit NodeNext-compatible extensions from internal type re-exports.
+// @ts-ignore TypeScript resolves these exports correctly in client projects using Bundler resolution.
+import type { FormComponentProps, FormComponentSlotProps } from '@inertiajs/core'
 
 import { useTuyau } from './context.ts'
-import type { RouteParams, RouteParamsFormats, Routes } from '../common.ts'
+import type { ExtractRouteBody, RouteParams, RouteParamsFormats, Routes } from '../common.ts'
 
+/**
+ * Inertia form slot aliases kept for backward compatibility.
+ */
 export type InertiaFormSlots = InstanceType<typeof InertiaForm>['$slots']
 export type InertiaFormDefaultSlot = InertiaFormSlots['default']
-export type InertiaFormSlotProps = InertiaFormDefaultSlot extends (...args: any[]) => any
-  ? Parameters<InertiaFormDefaultSlot>[0]
-  : never
+export type InertiaFormSlotProps<FormData extends Record<string, any> = Record<string, any>> =
+  FormComponentSlotProps<FormData>
+
+type RenameRouteParams<T> = T extends { routeParams: infer Params }
+  ? Omit<T, 'routeParams'> & { params: Params }
+  : T extends { routeParams?: infer Params }
+    ? Omit<T, 'routeParams'> & { params?: Params }
+    : T
 
 /**
  * Parameters required for route navigation with proper type safety.
  */
-export type FormParams<Route extends keyof Routes> = RouteParams<Route>
+export type FormParams<Route extends keyof Routes> = RenameRouteParams<RouteParams<Route>>
+
+export type FormRouteProps<Route extends keyof Routes> = Omit<
+  FormComponentProps<ExtractRouteBody<Route>>,
+  'action' | 'method'
+> &
+  FormParams<Route> & {
+    action?: never
+  }
+
+export type FormActionProps<FormData extends Record<string, any> = Record<string, any>> = Omit<
+  FormComponentProps<FormData>,
+  'route' | 'params'
+> & {
+  route?: never
+  params?: never
+}
+
+type FormComponentContext<FormData extends Record<string, any>, Props> = {
+  props: PublicProps & Props
+  expose: (exposed: {}) => void
+  attrs: any
+  slots: {
+    default: (props: InertiaFormSlotProps<FormData>) => any
+  }
+  emit: {}
+}
+
+type FormComponentVNode<FormData extends Record<string, any>, Props> = VNode & {
+  __ctx?: FormComponentContext<FormData, Props>
+}
+
+type FormComponent = {
+  <Route extends keyof Routes>(
+    props: PublicProps & FormRouteProps<Route>
+  ): FormComponentVNode<ExtractRouteBody<Route>, FormRouteProps<Route>>
+  <FormData extends Record<string, any> = Record<string, any>>(
+    props: PublicProps & FormActionProps<FormData>
+  ): FormComponentVNode<FormData, FormActionProps<FormData>>
+  /**
+   * Combined signature used by programmatic render helpers such as Vue's h().
+   */
+  <Route extends keyof Routes, FormData extends Record<string, any> = Record<string, any>>(
+    props: PublicProps & (FormRouteProps<Route> | FormActionProps<FormData>)
+  ): FormComponentVNode<
+    ExtractRouteBody<Route> | FormData,
+    FormRouteProps<Route> | FormActionProps<FormData>
+  >
+}
 
 /**
  * Type-safe Form component for Inertia.js form submissions.
@@ -46,19 +105,16 @@ export type FormParams<Route extends keyof Routes> = RouteParams<Route>
  * </Form>
  * ```
  */
-export const Form = defineComponent({
+const FormImplementation = defineComponent({
   name: 'TuyauForm',
   inheritAttrs: false,
-  slots: Object as SlotsType<{
-    default: InertiaFormSlotProps
-  }>,
   props: {
     route: {
       type: String as PropType<keyof Routes>,
       required: false,
     },
     params: {
-      type: [Array, Object] as PropType<RouteParamsFormats<keyof Routes>>,
+      type: [Array, Object] as unknown as PropType<RouteParamsFormats<keyof Routes>>,
       required: false,
     },
     action: {
@@ -100,3 +156,5 @@ export const Form = defineComponent({
     }
   },
 })
+
+export const Form = FormImplementation as unknown as FormComponent

--- a/tests/types/form.registry.d.ts
+++ b/tests/types/form.registry.d.ts
@@ -1,0 +1,35 @@
+import type {} from '@tuyau/core/types'
+
+type Registry = {
+  routes: {
+    'users.index': {
+      methods: ['GET', 'HEAD']
+      pattern: '/'
+      tokens: [{ old: '/'; type: 0; val: '/'; end: '' }]
+      types: {
+        body: {}
+        paramsTuple: []
+        params: {}
+        query: {}
+        response: unknown
+      }
+    }
+    'users.store': {
+      methods: ['POST']
+      pattern: '/users'
+      tokens: [{ old: '/users'; type: 0; val: 'users'; end: '' }]
+      types: {
+        body: { email: string; remember?: boolean }
+        paramsTuple: []
+        params: {}
+        query: {}
+        response: unknown
+      }
+    }
+  }
+  $tree: unknown
+}
+
+declare module '@tuyau/core/types' {
+  interface UserRegistry extends Registry {}
+}

--- a/tests/types/react_form.fixture.tsx
+++ b/tests/types/react_form.fixture.tsx
@@ -1,0 +1,88 @@
+import { createRef } from 'react'
+import type { FormComponentRef } from '@inertiajs/core'
+
+import { Form } from '../../src/client/react/form.tsx'
+
+type RouteBody = { email: string; remember?: boolean }
+
+const ref = createRef<FormComponentRef<RouteBody>>()
+const invalidRef = createRef<FormComponentRef<{ name: string }>>()
+
+export function RouteForm() {
+  return (
+    <Form
+      route="users.store"
+      ref={ref}
+      resetOnSuccess={['email', 'remember']}
+      resetOnError={['email']}
+      transform={(data) => ({ ...data, email: data.email.trim() })}
+    >
+      {({ errors, getData, reset }) => {
+        errors.email
+        getData().email
+        reset('email', 'remember')
+
+        // @ts-expect-error unknown route body field
+        errors.unknown
+        // @ts-expect-error unknown route body field
+        getData().unknown
+        // @ts-expect-error unknown route body field
+        reset('unknown')
+
+        return null
+      }}
+    </Form>
+  )
+}
+
+export function InvalidRouteFormRef() {
+  return (
+    // @ts-expect-error ref body must match the selected route body
+    <Form route="users.store" ref={invalidRef} />
+  )
+}
+
+export function InvalidRouteResetOptions() {
+  return (
+    // @ts-expect-error unknown route body field
+    <Form route="users.store" resetOnSuccess={['unknown']} />
+  )
+}
+
+export function DirectActionForm() {
+  return (
+    <Form<{ title: string }>
+      action={{ url: '/posts', method: 'post' }}
+      transform={(data) => ({ title: data.title.trim() })}
+    >
+      {({ getData, reset }) => {
+        getData().title
+        reset('title')
+
+        // @ts-expect-error unknown direct-action body field
+        getData().unknown
+
+        return null
+      }}
+    </Form>
+  )
+}
+
+export function InferredDirectActionForm() {
+  return (
+    <Form
+      action={{ url: '/posts', method: 'post' }}
+      transform={(data: { slug: string }) => ({ slug: data.slug.trim() })}
+    >
+      {({ getData, reset }) => {
+        getData().slug
+        reset('slug')
+
+        // @ts-expect-error unknown inferred direct-action body field
+        reset('unknown')
+
+        return null
+      }}
+    </Form>
+  )
+}

--- a/tests/types/tsconfig.react.json
+++ b/tests/types/tsconfig.react.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@adonisjs/tsconfig/tsconfig.client.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["./form.registry.d.ts", "./react_form.fixture.tsx"]
+}

--- a/tests/types/tsconfig.vue.json
+++ b/tests/types/tsconfig.vue.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@adonisjs/tsconfig/tsconfig.client.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["./form.registry.d.ts", "./vue_form.fixture.vue"]
+}

--- a/tests/types/vue_form.fixture.vue
+++ b/tests/types/vue_form.fixture.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { Form } from '../../src/client/vue/form.ts'
+</script>
+
+<template>
+  <Form
+    route="users.store"
+    :reset-on-success="['email', 'remember']"
+    :reset-on-error="['email']"
+    :transform="(data) => ({ ...data, email: data.email.trim() })"
+    v-slot="{ errors, getData, reset }"
+  >
+    {{ errors.email }}
+    {{ getData().email }}
+    <button type="button" @click="reset('email', 'remember')">Reset</button>
+
+    <!-- @vue-expect-error unknown route body field -->
+    {{ errors.unknown }}
+    <!-- @vue-expect-error unknown route body field -->
+    {{ getData().unknown }}
+    <!-- @vue-expect-error unknown route body field -->
+    <button type="button" @click="reset('unknown')">Invalid reset</button>
+  </Form>
+
+  <Form :action="{ url: '/users', method: 'post' }" v-slot="{ errors, getData, reset }">
+    {{ errors.anyField }}
+    {{ getData().anyField }}
+    <button type="button" @click="reset('anyField')">Reset</button>
+  </Form>
+</template>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,10 @@
     "rootDir": "./",
     "outDir": "./build",
     "jsx": "react-jsx"
-  }
+  },
+  "exclude": [
+    "tests/types/form.registry.d.ts",
+    "tests/types/react_form.fixture.tsx",
+    "tests/types/vue_form.fixture.vue"
+  ]
 }


### PR DESCRIPTION
Hey! 👋🏻 

Preserve the generated Tuyau route body type throughout Inertia v3's `Form` APIs for both React and Vue.

Route-based forms now expose the selected route body through:

- `errors`
- `getData`
- `reset` and other field-based helpers
- `transform`
- reset-related options
- React form refs

Direct-action forms keep Inertia's generic fallback and may still provide or infer a custom form body.

## React

The previous implementation derived its props from:

```ts
React.ComponentPropsWithoutRef<typeof InertiaForm>
```

Because Inertia v3's `Form` is generic, extracting the component props without specializing its form body erased `TForm`.

The wrapper now models Inertia's public form props, slot props, and ref explicitly and exposes separate overloads for route-based and direct-action forms.

## Vue

The Vue wrapper now exposes a generic public component shape that preserves the correlation between the `route` prop and its generated request body.

Typing is verified using a real `.vue` fixture checked by `vue-tsc`, rather than relying only on runtime `h()` smoke tests.

The existing `InertiaFormSlots` and `InertiaFormDefaultSlot` aliases remain exported for backward compatibility.

## NodeNext type-resolution workaround

`@adonisjs/inertia` is typechecked using NodeNext resolution, while frontend applications normally use Bundler resolution.

The declarations published by `@inertiajs/core` contain extensionless internal re-exports such as:

```ts
export * from './types'
```

NodeNext expects an ESM-compatible extension such as `./types.js`, so it does not expose `FormComponentProps`, `FormComponentSlotProps`, and `FormComponentRef` correctly from the package root.

Bundler resolution handles these declarations correctly.

The source imports therefore include a targeted `@ts-ignore` for the package build. The emitted declarations retain the proper public imports, and React/Vue consumer fixtures validate them under Bundler resolution. This workaround can be removed once Inertia publishes NodeNext-compatible declaration re-exports.

(This is something we should check in `@adonisjs/core`)