### PR TITLE
fix: preserve clear history across redirects

### DIFF
--- a/src/asset_version.ts
+++ b/src/asset_version.ts
@@ -1,0 +1,27 @@
+/*
+ * @adonisjs/inertia
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import type { RequestInfo } from './types.js'
+
+/**
+ * Returns whether an Inertia request must be replaced by an asset-version
+ * reload. The middleware owns the reload response; page construction uses the
+ * same predicate only to avoid consuming state before that response is issued.
+ */
+export function shouldReloadForAssetVersion(
+  requestInfo: RequestInfo,
+  requestMethod: string,
+  serverVersion: string
+) {
+  return (
+    requestInfo.isInertiaRequest &&
+    requestMethod === 'GET' &&
+    (requestInfo.version ?? '') !== serverVersion
+  )
+}

--- a/src/inertia.ts
+++ b/src/inertia.ts
@@ -16,6 +16,7 @@ import Macroable from '@poppinss/macroable'
 import type { HttpContext } from '@adonisjs/core/http'
 
 import { InertiaHeaders } from './headers.js'
+import { shouldReloadForAssetVersion } from './asset_version.js'
 import { type ServerRenderer } from './server_renderer.js'
 import type {
   PageProps,
@@ -41,6 +42,8 @@ import {
 } from './props.ts'
 import debug from './debug.ts'
 import { type AsyncOrSync } from '@poppinss/utils/types'
+
+const CLEAR_HISTORY_SESSION_KEY = 'inertia.clear_history'
 
 /**
  * Main class used to interact with Inertia
@@ -678,7 +681,15 @@ export class Inertia<Pages> extends Macroable {
      * unless they are `true` (the client defaults both to `false` when absent).
      * We only emit them when enabled to match the v3 wire format.
      */
-    if (this.#shouldClearHistory) {
+    const willReloadForAssetVersion = shouldReloadForAssetVersion(
+      requestInfo,
+      this.ctx.request.method(),
+      this.getVersion()
+    )
+    const shouldClearHistoryFromSession = willReloadForAssetVersion
+      ? false
+      : this.ctx.session?.pull(CLEAR_HISTORY_SESSION_KEY, false) === true
+    if (this.#shouldClearHistory || shouldClearHistoryFromSession) {
       pageObject.clearHistory = true
     }
     if (this.#shouldEncryptHistory) {
@@ -757,16 +768,19 @@ export class Inertia<Pages> extends Macroable {
   /**
    * Clear the browser history on the next navigation
    *
-   * Instructs the client to clear the browser history stack when navigating.
+   * Instructs the client to clear the browser history stack when navigating. When
+   * session middleware is in use, the instruction survives redirects and is
+   * consumed by the next Inertia page response.
    *
    * @example
    * ```js
    * inertia.clearHistory()
-   * return inertia.render('Dashboard', props)
+   * return inertia.location('/login')
    * ```
    */
   clearHistory() {
     this.#shouldClearHistory = true
+    this.ctx.session?.put(CLEAR_HISTORY_SESSION_KEY, true)
   }
 
   /**

--- a/src/inertia_middleware.ts
+++ b/src/inertia_middleware.ts
@@ -13,6 +13,7 @@ import type { HttpContext } from '@adonisjs/core/http'
 
 import type { Inertia } from '../index.ts'
 import { InertiaHeaders } from './headers.js'
+import { shouldReloadForAssetVersion } from './asset_version.js'
 import { InertiaManager } from './inertia_manager.ts'
 import type { ComponentProps, FlashData, InertiaPages, PageProps } from './types.js'
 import debug from './debug.ts'
@@ -239,8 +240,7 @@ export default abstract class BaseInertiaMiddleware {
      * See https://inertiajs.com/the-protocol#asset-versioning
      */
     const version = ctx.inertia.getVersion()
-    const clientVersion = requestInfo.version ?? ''
-    if (method === 'GET' && clientVersion !== version) {
+    if (shouldReloadForAssetVersion(requestInfo, method, version)) {
       debug('version mis-match. Reloading page')
       if (ctx.session) {
         ctx.session.reflash()

--- a/tests/inertia.spec.ts
+++ b/tests/inertia.spec.ts
@@ -46,6 +46,23 @@ test.group('Inertia', () => {
     assert.equal(ctx.response.getHeader(InertiaHeaders.Location), 'https://adonisjs.com')
   })
 
+  test('cannot carry clear history through a location response without a session', async ({
+    assert,
+  }) => {
+    const logoutContext = new HttpContextFactory().create()
+    const logoutInertia = new InertiaFactory().merge({ ctx: logoutContext }).create()
+
+    logoutInertia.clearHistory()
+    logoutInertia.location('/login')
+
+    assert.equal(logoutContext.response.getStatus(), 409)
+    assert.equal(logoutContext.response.getHeader(InertiaHeaders.Location), '/login')
+
+    const loginInertia = new InertiaFactory().create()
+    const loginPage: any = await loginInertia.render('login', {})
+    assert.notProperty(loginPage, 'clearHistory')
+  })
+
   test('calling inertia.render should set the X-Inertia header', async ({ assert }) => {
     setupViewMacroMock()
 
@@ -634,7 +651,7 @@ test.group('Inertia', () => {
     assert.isTrue(result.encryptHistory)
   })
 
-  test('clear history per request', async ({ assert }) => {
+  test('clear history on the same response without session middleware', async ({ assert }) => {
     const inertia = new InertiaFactory().create()
 
     inertia.clearHistory()

--- a/tests/middleware.spec.ts
+++ b/tests/middleware.spec.ts
@@ -9,6 +9,7 @@
 
 import supertest from 'supertest'
 import { test } from '@japa/runner'
+import { createServer } from 'node:http'
 import { type HttpContext } from '@adonisjs/core/http'
 import { type NextFn } from '@adonisjs/core/types/http'
 import { SessionMiddlewareFactory } from '@adonisjs/session/factories'
@@ -30,6 +31,75 @@ class InertiaMiddleware extends BaseInertiaMiddleware {
     this.dispose(ctx)
   }
 }
+
+const AUTH_SESSION_KEY = 'test.auth.user_id'
+
+const clearHistoryServer = test.macro(async ($test) => {
+  const { app } = await setupApp([
+    {
+      file: () => import('../providers/inertia_provider.ts'),
+      environment: ['web', 'test'],
+    },
+  ])
+  $test.cleanup(() => app.terminate())
+
+  const sessionMiddleware = await new SessionMiddlewareFactory().create()
+  const server = createServer(async (req, res) => {
+    const request = new RequestFactory().merge({ req, res }).create()
+    const response = new ResponseFactory().merge({ req, res }).create()
+    const ctx = new HttpContextFactory().merge({ request, response }).create()
+    ctx.containerResolver = app.container.createResolver()
+
+    await sessionMiddleware.handle(ctx, async () => {
+      const middleware = new InertiaMiddleware()
+      await middleware.handle(ctx, async () => {
+        if (ctx.request.url() === '/account') {
+          ctx.session.put(AUTH_SESSION_KEY, 1)
+          ctx.inertia.encryptHistory()
+          ctx.response.send(
+            await ctx.inertia.render('settings/show', { preference: 'authenticated' })
+          )
+          return
+        }
+
+        if (ctx.request.url() === '/logout-location') {
+          /**
+           * The adapter does not depend on @adonisjs/auth. From its boundary,
+           * session-guard logout means removing the authentication state from
+           * this session before issuing the clear-history location response.
+           */
+          ctx.session.forget(AUTH_SESSION_KEY)
+          ctx.inertia.clearHistory()
+          ctx.inertia.location('/login')
+          return
+        }
+
+        if (ctx.request.url() === '/logout-redirect') {
+          ctx.inertia.clearHistory()
+          ctx.response.redirect('/login')
+          return
+        }
+
+        if (ctx.request.url() === '/health') {
+          ctx.response.send('ok')
+          return
+        }
+
+        ctx.response.send(
+          await ctx.inertia.render('settings/show', {
+            preference: ctx.session.has(AUTH_SESSION_KEY) ? 'authenticated' : 'guest',
+          })
+        )
+      })
+    })
+
+    ctx.response.finish()
+  })
+  $test.cleanup(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  })
+  return server
+})
 
 test.group('Middleware', () => {
   test('add inertia to HTTP context', async ({ assert, cleanup }) => {
@@ -273,6 +343,123 @@ test.group('Middleware', () => {
     assert.isUndefined(response.headers[InertiaHeaders.Inertia])
     assert.equal(response.headers[InertiaHeaders.Location], '/')
     assert.equal(response.headers[InertiaHeaders.Version], '1')
+  })
+
+  test('carry clear history through a location response after session-backed logout and consume it once', async ({
+    assert,
+  }) => {
+    const server = await clearHistoryServer()
+
+    const client = supertest.agent(server)
+    const accountResponse = await client
+      .get('/account')
+      .set(InertiaHeaders.Inertia, 'true')
+      .set(InertiaHeaders.Version, '1')
+    assert.isTrue(accountResponse.body.encryptHistory)
+    assert.equal(accountResponse.body.props.preference, 'authenticated')
+
+    const logoutResponse = await client
+      .post('/logout-location')
+      .set(InertiaHeaders.Inertia, 'true')
+      .set(InertiaHeaders.Version, '1')
+    assert.equal(logoutResponse.status, 409)
+    assert.equal(logoutResponse.headers[InertiaHeaders.Location], '/login')
+
+    const loginResponse = await client
+      .get('/login')
+      .set(InertiaHeaders.Inertia, 'true')
+      .set(InertiaHeaders.Version, '1')
+    assert.isTrue(loginResponse.body.clearHistory)
+    assert.equal(loginResponse.body.props.preference, 'guest')
+
+    const nextLoginResponse = await client
+      .get('/login')
+      .set(InertiaHeaders.Inertia, 'true')
+      .set(InertiaHeaders.Version, '1')
+    assert.notProperty(nextLoginResponse.body, 'clearHistory')
+  })
+
+  test('carry clear history through an ordinary redirect', async ({ assert }) => {
+    const server = await clearHistoryServer()
+    const client = supertest.agent(server)
+
+    const logoutResponse = await client
+      .delete('/logout-redirect')
+      .set(InertiaHeaders.Inertia, 'true')
+      .set(InertiaHeaders.Version, '1')
+    assert.equal(logoutResponse.status, 303)
+    assert.equal(logoutResponse.headers.location, '/login')
+
+    const loginResponse = await client
+      .get('/login')
+      .set(InertiaHeaders.Inertia, 'true')
+      .set(InertiaHeaders.Version, '1')
+    assert.isTrue(loginResponse.body.clearHistory)
+  })
+
+  test('do not consume clear history on a non-Inertia response', async ({ assert }) => {
+    const server = await clearHistoryServer()
+    const client = supertest.agent(server)
+
+    await client
+      .post('/logout-location')
+      .set(InertiaHeaders.Inertia, 'true')
+      .set(InertiaHeaders.Version, '1')
+
+    const healthResponse = await client.get('/health')
+    assert.equal(healthResponse.text, 'ok')
+
+    const loginResponse = await client
+      .get('/login')
+      .set(InertiaHeaders.Inertia, 'true')
+      .set(InertiaHeaders.Version, '1')
+    assert.isTrue(loginResponse.body.clearHistory)
+  })
+
+  test('preserve clear history through an asset version reload', async ({ assert }) => {
+    const server = await clearHistoryServer()
+    const client = supertest.agent(server)
+
+    await client
+      .post('/logout-location')
+      .set(InertiaHeaders.Inertia, 'true')
+      .set(InertiaHeaders.Version, '1')
+
+    const staleVersionResponse = await client
+      .get('/login')
+      .set(InertiaHeaders.Inertia, 'true')
+      .set(InertiaHeaders.Version, '2')
+    assert.equal(staleVersionResponse.status, 409)
+    assert.equal(staleVersionResponse.headers[InertiaHeaders.Location], '/login')
+
+    const loginResponse = await client
+      .get('/login')
+      .set(InertiaHeaders.Inertia, 'true')
+      .set(InertiaHeaders.Version, '1')
+    assert.isTrue(loginResponse.body.clearHistory)
+  })
+
+  test('isolate clear history between sessions', async ({ assert }) => {
+    const server = await clearHistoryServer()
+    const firstClient = supertest.agent(server)
+    const secondClient = supertest.agent(server)
+
+    await firstClient
+      .post('/logout-location')
+      .set(InertiaHeaders.Inertia, 'true')
+      .set(InertiaHeaders.Version, '1')
+
+    const secondLoginResponse = await secondClient
+      .get('/login')
+      .set(InertiaHeaders.Inertia, 'true')
+      .set(InertiaHeaders.Version, '1')
+    assert.notProperty(secondLoginResponse.body, 'clearHistory')
+
+    const firstLoginResponse = await firstClient
+      .get('/login')
+      .set(InertiaHeaders.Inertia, 'true')
+      .set(InertiaHeaders.Version, '1')
+    assert.isTrue(firstLoginResponse.body.clearHistory)
   })
 })
 


### PR DESCRIPTION
Hi! 👋🏻

This PR makes `clearHistory()` survive redirects.

Previously, `clearHistory()` only stored the intent on the current Inertia instance. Since redirects such as `inertia.location()` do not serialize an Inertia page, that intent was lost before the next request and the browser history was not cleared.

When session middleware is available, `clearHistory()` now stores an internal session marker. The next Inertia page consumes this marker exactly once and includes `clearHistory: true` in the serialized page.

This follows the same approach used by [`inertia-laravel`](https://github.com/inertiajs/inertia-laravel/blob/3.x/src/ResponseFactory.php#L184-L190).