### PR TITLE
Feat/svelte client adapter

### DIFF
--- a/commands/make_page.ts
+++ b/commands/make_page.ts
@@ -30,6 +30,9 @@ export default class MakePage extends BaseCommand {
   @flags.boolean({ description: 'Create a React page component' })
   declare react: boolean
 
+  @flags.boolean({ description: 'Create a Svelte page component' })
+  declare svelte: boolean
+
   /**
    * Read the contents from this file (if the flag exists) and use
    * it as the raw contents
@@ -52,19 +55,23 @@ export default class MakePage extends BaseCommand {
    * Detect the framework by scanning existing files in the
    * inertia/pages directory.
    */
-  async #detectFramework(): Promise<'vue' | 'react' | null> {
+  async #detectFramework(): Promise<'vue' | 'react' | 'svelte' | null> {
     try {
       const pagesDir = this.app.makePath(this.pagesDir)
       const files = await readdir(pagesDir, { recursive: true })
 
       const hasVue = files.some((file) => file.endsWith('.vue'))
       const hasReact = files.some((file) => file.endsWith('.tsx') || file.endsWith('.jsx'))
+      const hasSvelte = files.some((file) => file.endsWith('.svelte'))
 
-      if (hasVue && !hasReact) {
+      if (hasVue && !hasReact && !hasSvelte) {
         return 'vue'
       }
-      if (hasReact && !hasVue) {
+      if (hasReact && !hasVue && !hasSvelte) {
         return 'react'
+      }
+      if (hasSvelte && !hasVue && !hasReact) {
+        return 'svelte'
       }
 
       return null
@@ -77,12 +84,15 @@ export default class MakePage extends BaseCommand {
    * Resolve which framework to use. Flags take priority,
    * then auto-detection, and finally prompt the user.
    */
-  async #resolveFramework(): Promise<'vue' | 'react'> {
+  async #resolveFramework(): Promise<'vue' | 'react' | 'svelte'> {
     if (this.vue) {
       return 'vue'
     }
     if (this.react) {
       return 'react'
+    }
+    if (this.svelte) {
+      return 'svelte'
     }
 
     const detected = await this.#detectFramework()
@@ -90,7 +100,7 @@ export default class MakePage extends BaseCommand {
       return detected
     }
 
-    return this.prompt.choice('Select the frontend framework', ['vue', 'react'])
+    return this.prompt.choice('Select the frontend framework', ['vue', 'react', 'svelte'])
   }
 
   async run() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@adonisjs/vite": "^6.0.1",
         "@ast-grep/cli": "^0.45.1",
         "@inertiajs/react": "^3.7.0",
+        "@inertiajs/svelte": "^3.7.0",
         "@inertiajs/vue3": "^3.7.0",
         "@japa/api-client": "^3.2.1",
         "@japa/assert": "4.2.0",
@@ -49,6 +50,9 @@
         "react": "^19.2.8",
         "release-it": "^21.0.2",
         "supertest": "^7.2.2",
+        "svelte": "^5.56.9",
+        "svelte-check": "^4.7.6",
+        "svelte2tsx": "^0.7.61",
         "tsdown": "^0.22.14",
         "typescript": "~6.0.3",
         "vite": "^8.2.2",
@@ -65,12 +69,14 @@
         "@adonisjs/vite": "^6.0.0-next.0 || ^6.0.0",
         "@inertiajs/core": "^3.4.0",
         "@inertiajs/react": "^3.4.0",
+        "@inertiajs/svelte": "^3.4.0",
         "@inertiajs/vue3": "^3.4.0",
         "@japa/api-client": "^3.1.1",
         "@japa/plugin-adonisjs": "^5.1.0-next.1 || ^5.1.0",
         "@tuyau/core": "^1.0.0-beta.10 || ^1.0.0",
         "edge.js": "^6.4.0",
         "react": "^19.2.3",
+        "svelte": "^5.0.0",
         "vue": "^3.5.17"
       },
       "peerDependenciesMeta": {
@@ -81,6 +87,9 @@
           "optional": true
         },
         "@inertiajs/react": {
+          "optional": true
+        },
+        "@inertiajs/svelte": {
           "optional": true
         },
         "@inertiajs/vue3": {
@@ -96,6 +105,9 @@
           "optional": true
         },
         "react": {
+          "optional": true
+        },
+        "svelte": {
           "optional": true
         },
         "vue": {
@@ -1432,6 +1444,21 @@
         "react-dom": "^19.0.0"
       }
     },
+    "node_modules/@inertiajs/svelte": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@inertiajs/svelte/-/svelte-3.7.0.tgz",
+      "integrity": "sha512-vEUmVQQrXtv37ohJd13Run6mF0QG5udPu47tJ5SAbvGhyNGVtlJrZJjGp6ooe+mdcjAGiNz1ZPRgZDvI2yP0zA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inertiajs/core": "3.7.0",
+        "es-toolkit": "^1.33.0",
+        "laravel-precognition": "^2.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0"
+      }
+    },
     "node_modules/@inertiajs/vue3": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@inertiajs/vue3/-/vue3-3.7.0.tgz",
@@ -2086,6 +2113,28 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -3053,6 +3102,26 @@
         "eslint": "^9.0.0 || ^10.0.0"
       }
     },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.13.tgz",
+      "integrity": "sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@sveltejs/load-config": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.3.tgz",
+      "integrity": "sha512-VT3qmUb8pRV2QrZjd8iAmtg8lf4W0TIjZbvXtz5MKei/q96teWZgGJyyidJzOjzZzvdq616eSRVeMYIQChUTAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
     "node_modules/@swc/core": {
       "version": "1.15.47",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.47.tgz",
@@ -3535,6 +3604,13 @@
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -4443,6 +4519,16 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -4508,6 +4594,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/balanced-match": {
@@ -5133,6 +5229,16 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/code-block-writer": {
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
@@ -5647,6 +5753,13 @@
         }
       }
     },
+    "node_modules/dedent-js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
+      "integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5813,6 +5926,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/devalue": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.1.tgz",
+      "integrity": "sha512-+17vil3EVQRzvtDJSFuTWEb8XJRvXqAiV3qZyQWD398QeXUa6CxsUyMdD1fxzEhUrd4FojitFz7lhIHBTlV4fw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -6370,6 +6490,13 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -6413,6 +6540,24 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/esrap": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.3.5.tgz",
+      "integrity": "sha512-KciPkeZZX8srrh6xELzLR2cBaWOzgBQ4CwggO6Dh/KMlrfOcIcfyXCVy/Vvc3/OlS5gvFOd5tcxUYuaGM8o45A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/esrecurse": {
@@ -7716,6 +7861,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
     "node_modules/is-ssh": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.1.tgz",
@@ -8342,6 +8497,13 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -8689,6 +8851,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -10178,6 +10350,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -10220,6 +10405,14 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/scule": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
+      "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
       "dev": true,
       "license": "MIT"
     },
@@ -10773,6 +10966,104 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.56.10",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.10.tgz",
+      "integrity": "sha512-Lcxbj8I/KAbpY+VjtY4ENQBV0dDCipfGAhqb51XQZ67CIQqXgsv/8dPkbILaj4Fb6/b6JAEM/PIVbILXgDQy2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.12",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/svelte-check": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.6.tgz",
+      "integrity": "sha512-t2scM//ZuVbSY/T2w6FSBw1v9s2NEmh/g+sy1lqtosW5ylBV5AF4wFb1Ts9Kf3MbfPDUDJDZ9L436YT0SPTdvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@sveltejs/load-config": "^0.2.3",
+        "chokidar": "^4.0.1",
+        "fdir": "^6.2.0",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/svelte-check/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/svelte-check/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/svelte2tsx": {
+      "version": "0.7.61",
+      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.7.61.tgz",
+      "integrity": "sha512-EpQ/+UHITBULeUojx/LLD3uTYasZXcX1BrqlrzfLUnT9vdUhaOWK59a3ryWcFU8L0sY1SP+gRhJ2Beiis98+qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dedent-js": "^1.0.1",
+        "scule": "^1.3.0"
+      },
+      "peerDependencies": {
+        "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0",
+        "typescript": "^4.9.4 || ^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/synckit": {
@@ -11867,6 +12158,13 @@
         "@yuku-parser/binding-win32-arm64": "0.8.4",
         "@yuku-parser/binding-win32-x64": "0.8.4"
       }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,21 +20,25 @@
     "./helpers": "./build/src/client/helpers.js",
     "./react": "./build/src/client/react/index.js",
     "./vue": "./build/src/client/vue/index.js",
+    "./svelte": "./build/src/client/svelte/index.js",
     "./factories": "./build/factories/main.js",
     "./commands": "./build/commands/main.js"
   },
   "scripts": {
     "pretest": "npm run lint",
     "test": "npm run quick:test",
-    "typecheck": "npm run typecheck:node && npm run typecheck:client",
+    "typecheck": "npm run typecheck:node && npm run typecheck:client && npm run typecheck:svelte",
     "typecheck:node": "tsc --noEmit",
     "typecheck:client": "vue-tsc --noEmit -p tests/types/tsconfig.json",
+    "typecheck:svelte": "svelte-check --tsconfig tests/types/svelte/tsconfig.json",
     "clean": "del-cli build",
     "compile": "tsdown && tsc --emitDeclarationOnly --declaration",
     "copy:templates": "copyfiles \"stubs/**/*.stub\" build",
+    "copy:svelte": "copyfiles \"src/client/svelte/**/*.svelte\" build",
+    "emit:svelte-dts": "node scripts/emit_svelte_dts.mjs",
     "prebuild": "npm run lint && npm run clean",
     "build": "npm run compile",
-    "postcompile": "npm run copy:templates && npm run index:commands",
+    "postcompile": "npm run copy:templates && npm run copy:svelte && npm run emit:svelte-dts && npm run index:commands",
     "prebenchmark": "npm run build",
     "benchmark": "node benchmarks/index.js",
     "release": "release-it",
@@ -44,7 +48,7 @@
     "lint": "eslint",
     "lint:ast": "ast-grep scan",
     "index:commands": "adonis-kit index build/commands",
-    "quick:test": "cross-env NODE_DEBUG=adonisjs:inertia node --import=@poppinss/ts-exec --enable-source-maps bin/test.ts",
+    "quick:test": "cross-env NODE_DEBUG=adonisjs:inertia node --conditions=svelte --import=@poppinss/ts-exec --import=./tests/support/register_svelte_loader.mjs --enable-source-maps bin/test.ts",
     "docs": "typedoc"
   },
   "devDependencies": {
@@ -58,6 +62,7 @@
     "@ast-grep/cli": "^0.45.1",
     "@inertiajs/react": "^3.7.0",
     "@inertiajs/vue3": "^3.7.0",
+    "@inertiajs/svelte": "^3.7.0",
     "@japa/api-client": "^3.2.1",
     "@japa/assert": "4.2.0",
     "@japa/expect-type": "^2.0.4",
@@ -82,6 +87,9 @@
     "react": "^19.2.8",
     "release-it": "^21.0.2",
     "supertest": "^7.2.2",
+    "svelte": "^5.56.9",
+    "svelte-check": "^4.7.6",
+    "svelte2tsx": "^0.7.61",
     "tsdown": "^0.22.14",
     "typescript": "~6.0.3",
     "vite": "^8.2.2",
@@ -102,12 +110,14 @@
     "@inertiajs/core": "^3.4.0",
     "@inertiajs/react": "^3.4.0",
     "@inertiajs/vue3": "^3.4.0",
+    "@inertiajs/svelte": "^3.4.0",
     "@japa/api-client": "^3.1.1",
     "@japa/plugin-adonisjs": "^5.1.0-next.1 || ^5.1.0",
     "@tuyau/core": "^1.0.0-beta.10 || ^1.0.0",
     "edge.js": "^6.4.0",
     "react": "^19.2.3",
-    "vue": "^3.5.17"
+    "vue": "^3.5.17",
+    "svelte": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "@adonisjs/assembler": {
@@ -125,6 +135,9 @@
     "vue": {
       "optional": true
     },
+    "svelte": {
+      "optional": true
+    },
     "@tuyau/core": {
       "optional": true
     },
@@ -135,6 +148,9 @@
       "optional": true
     },
     "@inertiajs/vue3": {
+      "optional": true
+    },
+    "@inertiajs/svelte": {
       "optional": true
     }
   },

--- a/scripts/emit_svelte_dts.mjs
+++ b/scripts/emit_svelte_dts.mjs
@@ -1,0 +1,52 @@
+/*
+ * @adonisjs/inertia
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Emits declaration files for the svelte client adapter.
+ *
+ * `tsc --emitDeclarationOnly` (the rest of `compile`) cannot cover this
+ * folder: it runs against the root tsconfig.json, which excludes
+ * src/client/svelte wholesale (see the comment there) because
+ * `@inertiajs/svelte` only resolves under Bundler resolution. svelte2tsx's
+ * `emitDts` is used instead, pointed at the same bundler-resolution tsconfig
+ * svelte-check already uses (tests/types/svelte/tsconfig.json), so the two
+ * stay in lockstep by construction.
+ *
+ * The v4 shims file is required, not the default one: against
+ * `svelte-shims.d.ts` (the pre-v4/legacy shim), emitDts cannot introspect
+ * Svelte 5 runes-mode `$props()` destructuring at all — every component's
+ * emitted props collapse to `Record<string, never>`, and Form's `export
+ * const` bindings (submit, reset, ...) get misread as props instead of
+ * component exports. Verified: `svelte-shims-v4.d.ts` fixes both, and is
+ * also what produces the generic `$$IsomorphicComponent` shape that keeps
+ * Link/Form's per-route generic (`Route extends keyof Routes`) intact in the
+ * emitted .d.ts, referencing this package's own `LinkProps<Route>` /
+ * `FormProps<Route>` from types.ts rather than flattening them.
+ *
+ * These .svelte.d.ts files are a fallback for tooling without a Svelte
+ * language plugin. A properly configured Svelte + TypeScript consumer (any
+ * real one — svelte-check, the Svelte VS Code/IDE extensions, SvelteKit's
+ * own tsconfig setup) resolves `.svelte` imports by analysing the shipped
+ * source directly, the same way this package's own svelte-check run does,
+ * and never consults these declaration files at all.
+ */
+import { emitDts } from 'svelte2tsx'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const require = createRequire(import.meta.url)
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+await emitDts({
+  declarationDir: path.join(root, 'build/src/client/svelte'),
+  svelteShimsPath: require.resolve('svelte2tsx/svelte-shims-v4.d.ts'),
+  libRoot: path.join(root, 'src/client/svelte'),
+  tsconfig: path.join(root, 'tests/types/svelte/tsconfig.json'),
+})

--- a/src/client/helpers.ts
+++ b/src/client/helpers.ts
@@ -14,7 +14,7 @@
  *
  * @param path - The page path(s) to resolve. Can be a single string or array of strings
  * @param pages - Registry of page components where keys are paths and values are either promises or functions returning promises
- * @param layout - Optional layout component to assign to the resolved page
+ * @param layout - Optional layout component to assign to the resolved page. React and Vue only — see the note below
  * @returns Promise resolving to the page component
  *
  * @example
@@ -32,6 +32,26 @@
  * ```
  *
  * @throws Error When none of the provided paths can be resolved in the pages registry
+ *
+ * @remarks
+ * The `layout` argument is for React and Vue, which read a page's layout off
+ * the component (`component.layout`). Svelte reads it off the *module* — its
+ * `ResolvedComponent` is `{ default, layout? }` — so assigning it to the
+ * component here would never be seen, and the module namespace an eagerly
+ * globbed page resolves to is frozen anyway. A Svelte app declares its
+ * application-wide layout through `createInertiaApp`'s own `layout` option,
+ * and a page overrides it by exporting `layout` from a `<script module>`
+ * block; call this helper with two arguments and let those handle it.
+ *
+ * @example
+ * ```ts
+ * // Svelte
+ * createInertiaApp({
+ *   resolve: (name) =>
+ *     resolvePageComponent(`./pages/${name}.svelte`, import.meta.glob('./pages/**\/*.svelte')),
+ *   layout: () => DefaultLayout,
+ * })
+ * ```
  */
 export async function resolvePageComponent<T>(
   path: string | string[],

--- a/src/client/svelte/context.ts
+++ b/src/client/svelte/context.ts
@@ -102,7 +102,11 @@ export function tuyauContext<Registry extends TuyauRegistry>(client: Tuyau<Regis
  */
 export function useTuyau() {
   const context = getContext<Tuyau<any> | null>(TUYAU_CONTEXT)
-  if (!context) throw new Error('You must wrap your app in a TuyauProvider')
+  if (!context) {
+    throw new Error(
+      'No Tuyau client found in Svelte context. Register one via <TuyauProvider>, provideTuyau(withAppContext, client), or tuyauContext(client).'
+    )
+  }
 
   return context
 }

--- a/src/client/svelte/context.ts
+++ b/src/client/svelte/context.ts
@@ -1,0 +1,108 @@
+/*
+ * @adonisjs/inertia
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { getContext, setContext } from 'svelte'
+import type { Tuyau } from '@tuyau/core/client'
+import type { TuyauRegistry } from '@tuyau/core/types'
+
+/**
+ * Svelte context key holding the Tuyau client.
+ *
+ * Registered on the global symbol registry rather than created with a bare
+ * `Symbol()`: the components are shipped as uncompiled `.svelte` files that
+ * import this module through a separate entrypoint from the one the package
+ * export subpath resolves, so the module can legitimately be instantiated
+ * more than once. A registry symbol keeps every instance agreeing on the
+ * same key, and is what the package already relies on for its prop markers.
+ */
+const TUYAU_CONTEXT = Symbol.for('Tuyau')
+
+/**
+ * Registers the Tuyau client on the current component's context.
+ *
+ * Prefer the `TuyauProvider` component; reach for this when the client is
+ * seeded from a component you already own, such as the root component the
+ * Inertia app is mounted with.
+ *
+ * @throws Error when called outside component initialisation
+ */
+export function setTuyau<Registry extends TuyauRegistry>(client: Tuyau<Registry>) {
+  setContext(TUYAU_CONTEXT, client)
+}
+
+/**
+ * Registers the Tuyau client on the context map `createInertiaApp` hands to
+ * its `withApp` hook.
+ *
+ * This is the way to install the client in an Inertia app. Svelte has no
+ * component wrapping the root of one — the app is mounted by
+ * `createInertiaApp` itself — and letting it do that mounting is what makes
+ * it hydrate server-rendered markup when SSR is on and mount from scratch
+ * when it is not. `withApp` runs on both sides of that split, and builds a
+ * fresh map per render on the server, so nothing leaks between requests.
+ *
+ * @example
+ * ```ts
+ * createInertiaApp({
+ *   resolve: (name) => resolvePageComponent(`./pages/${name}.svelte`, pages),
+ *   withApp(context) {
+ *     provideTuyau(context, tuyau)
+ *   },
+ * })
+ * ```
+ */
+export function provideTuyau<Registry extends TuyauRegistry>(
+  context: Map<any, any>,
+  client: Tuyau<Registry>
+) {
+  context.set(TUYAU_CONTEXT, client)
+}
+
+/**
+ * Builds the context map accepted by Svelte's `mount()`, `hydrate()`, and
+ * `render()`.
+ *
+ * Reach for this only when taking over mounting through `createInertiaApp`'s
+ * `setup` option, which owns the map itself and so cannot be fed through
+ * `provideTuyau`. Taking `setup` over means owning the CSR/SSR and
+ * mount/hydrate split too — prefer `withApp` and `provideTuyau` unless that
+ * is what you are after.
+ *
+ * @example
+ * ```ts
+ * createInertiaApp({
+ *   resolve: (name) => resolvePageComponent(`./pages/${name}.svelte`, pages),
+ *   setup({ el, App, props }) {
+ *     mount(App, { target: el, props, context: tuyauContext(tuyau) })
+ *   },
+ * })
+ * ```
+ */
+export function tuyauContext<Registry extends TuyauRegistry>(client: Tuyau<Registry>) {
+  const context = new Map<any, any>()
+  provideTuyau(context, client)
+
+  return context
+}
+
+/**
+ * Reads the Tuyau client from any component below a `TuyauProvider` (or
+ * below a root mounted with `tuyauContext`).
+ *
+ * Provides type-safe access to route generation and navigation utilities.
+ *
+ * @returns The Tuyau client instance with full type safety
+ * @throws Error if no client has been registered on the context
+ */
+export function useTuyau() {
+  const context = getContext<Tuyau<any> | null>(TUYAU_CONTEXT)
+  if (!context) throw new Error('You must wrap your app in a TuyauProvider')
+
+  return context
+}

--- a/src/client/svelte/form.svelte
+++ b/src/client/svelte/form.svelte
@@ -1,0 +1,126 @@
+<!--
+  @adonisjs/inertia
+
+  (c) AdonisJS
+
+  For the full copyright and license information, please view the LICENSE
+  file that was distributed with this source code.
+-->
+<!--
+  @component
+  Type-safe Form component for Inertia.js form submissions.
+
+  Provides compile-time route validation and automatic parameter type
+  checking based on your application's route definitions. Automatically
+  resolves the correct URL and HTTP method for each route. Alternatively,
+  you can use the standard action prop for direct form submission.
+
+  In route mode the form-data shape is derived from the route's declared
+  body, so the children snippet (errors, getData, reset, ...) follows the
+  route without a manual generic.
+
+  ```svelte
+  <Form route="users.store">
+    {#snippet children({ processing })}
+      <input type="text" name="name" />
+      <button type="submit" disabled={processing}>Create</button>
+    {/snippet}
+  </Form>
+
+  <Form route="users.update" routeParams={{ id: 1 }}>
+    {#snippet children({ errors })}
+      <input type="text" name="name" />
+      {#if errors.name}<div>{errors.name}</div>{/if}
+      <button type="submit">Update</button>
+    {/snippet}
+  </Form>
+
+  <Form action={{ url: '/users', method: 'post' }}>
+    {#snippet children({ processing })}
+      <input type="text" name="name" />
+      <button type="submit" disabled={processing}>Create</button>
+    {/snippet}
+  </Form>
+  ```
+-->
+<script
+  lang="ts"
+  generics="Route extends keyof Routes, FormData extends Record<string, any> = FormDataType<ExtractRouteBody<Route>>"
+>
+  import { Form as InertiaForm } from '@inertiajs/svelte'
+  // Inertia's declarations omit NodeNext-compatible extensions from internal type re-exports.
+  // prettier-ignore
+  // @ts-ignore TypeScript resolves this export correctly in client projects using Bundler resolution.
+  import type { FormDataType } from '@inertiajs/core'
+
+  import { buildRouteUrl, useTuyau } from './internals.js'
+  import type { ExtractRouteBody, Routes } from '../types.ts'
+  import type { FormProps, FormRouteProps } from './types.ts'
+
+  /**
+   * `FormData` is a second type parameter rather than only a default on
+   * FormProps so action mode stays inferable: with no route to derive the
+   * form-data shape from, it is recovered from an annotated `children`
+   * snippet parameter instead. Route mode never supplies it and falls to the
+   * default, which follows the route's declared body.
+   */
+  const props: FormProps<Route, FormData> = $props()
+
+  /**
+   * Read during initialisation: svelte contexts are only readable while the
+   * component is being set up, so this cannot be deferred into the derived
+   * below.
+   */
+  const tuyau = useTuyau()
+
+  /**
+   * Forwarded so `bind:this` on the wrapper reaches the upstream form API
+   * (submit, reset, setError, ...) instead of the wrapper itself.
+   */
+  let inner = $state<any>(undefined)
+
+  export const getFormData = (...args: any[]) => inner?.getFormData(...args)
+  export const getData = (...args: any[]) => inner?.getData(...args)
+  export const submit = (...args: any[]) => inner?.submit(...args)
+  export const reset = (...args: any[]) => inner?.reset(...args)
+  export const clearErrors = (...args: any[]) => inner?.clearErrors(...args)
+  export const resetAndClearErrors = (...args: any[]) => inner?.resetAndClearErrors(...args)
+  export const setError = (...args: any[]) => inner?.setError(...args)
+  export const defaults = (...args: any[]) => inner?.defaults(...args)
+  export const validate = (...args: any[]) => inner?.validate(...args)
+  export const valid = (...args: any[]) => inner?.valid(...args)
+  export const invalid = (...args: any[]) => inner?.invalid(...args)
+  export const touch = (...args: any[]) => inner?.touch(...args)
+  export const touched = (...args: any[]) => inner?.touched(...args)
+  export const validator = (...args: any[]) => inner?.validator(...args)
+
+  /**
+   * Route-based navigation. getRoute resolves the HTTP methods and urlFor
+   * builds the URL, serializing query string parameters in one place.
+   *
+   * The action mode short-circuits: the route bindings are stripped and
+   * every remaining prop is forwarded untouched, so a plain form behaves
+   * exactly like the upstream component.
+   */
+  const resolved = $derived.by(() => {
+    const { route, routeParams, qs, method, ...formProps } = props as FormRouteProps<Route> & {
+      action?: unknown
+    }
+
+    if (formProps.action !== undefined) {
+      return method === undefined ? formProps : { ...formProps, method }
+    }
+
+    const { methods } = tuyau.getRoute(route, { params: routeParams })
+
+    return {
+      ...formProps,
+      action: {
+        url: buildRouteUrl(tuyau, route, routeParams, qs),
+        method: method ?? methods[0].toLowerCase(),
+      },
+    }
+  })
+</script>
+
+<InertiaForm bind:this={inner} {...resolved} />

--- a/src/client/svelte/http.ts
+++ b/src/client/svelte/http.ts
@@ -1,0 +1,179 @@
+/*
+ * @adonisjs/inertia
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { useHttp as useInertiaHttp } from '@inertiajs/svelte'
+// Inertia's declarations omit NodeNext-compatible extensions from internal type re-exports.
+// prettier-ignore
+// @ts-ignore TypeScript resolves these exports in client projects using Bundler resolution.
+import type { FormDataKeys, FormDataType, Method, UrlMethodPair, UseHttpSubmitOptions } from '@inertiajs/core'
+
+import { useTuyau } from './context.ts'
+import { buildRouteUrl, normalizeValidationErrors } from '../common.ts'
+import type { ExtractRouteBody, RouteParams, Routes } from '../types.ts'
+
+/**
+ * Inertia HTTP form bound to a Tuyau route.
+ */
+export type RouteHttp<Route extends keyof Routes> = Omit<
+  ReturnType<
+    typeof useInertiaHttp<FormDataType<ExtractRouteBody<Route>>, Routes[Route]['types']['response']>
+  >,
+  | 'submit'
+  | 'get'
+  | 'post'
+  | 'put'
+  | 'patch'
+  | 'delete'
+  | 'withPrecognition'
+  | 'dontRemember'
+  | 'optimistic'
+  | 'withAllErrors'
+> & {
+  /**
+   * Submit the form to its bound route.
+   */
+  submit(
+    options?: UseHttpSubmitOptions<
+      Routes[Route]['types']['response'],
+      FormDataType<ExtractRouteBody<Route>>
+    >
+  ): Promise<Routes[Route]['types']['response']>
+
+  /**
+   * Exclude fields when the form state is remembered.
+   */
+  dontRemember(...fields: FormDataKeys<FormDataType<ExtractRouteBody<Route>>>[]): RouteHttp<Route>
+
+  /**
+   * Apply an optimistic data update to the next submission.
+   */
+  optimistic(
+    callback: (
+      data: FormDataType<ExtractRouteBody<Route>>
+    ) => Partial<FormDataType<ExtractRouteBody<Route>>>
+  ): RouteHttp<Route>
+
+  /**
+   * Preserve all validation messages returned for each field.
+   */
+  withAllErrors(): RouteHttp<Route>
+}
+
+function useHttpImplementation(...args: any[]) {
+  const tuyau = useTuyau()
+  const params = args[0]
+  let inertiaArgs = args
+
+  const isRouteMode =
+    typeof params === 'object' && params !== null && typeof params.route === 'string'
+
+  if (isRouteMode) {
+    const { methods } = tuyau.getRoute(params.route, { params: params.routeParams })
+    inertiaArgs = [
+      {
+        url: buildRouteUrl(tuyau, params.route, params.routeParams, params.qs),
+        method: params.method ?? methods[0].toLowerCase(),
+      },
+      args[1] ?? {},
+    ]
+  }
+
+  const request = (useInertiaHttp as (...httpArgs: any[]) => any)(...inertiaArgs)
+  const withErrorNormalization = (options: any = {}) => {
+    return {
+      ...options,
+      onError(errors: unknown) {
+        const normalizedErrors = normalizeValidationErrors(errors)
+
+        if (normalizedErrors !== errors) {
+          request.clearErrors()
+          request.setError(normalizedErrors)
+        }
+
+        options.onError?.(normalizedErrors)
+      },
+    }
+  }
+
+  for (const method of ['get', 'post', 'put', 'patch', 'delete']) {
+    const send = request[method]
+    request[method] = (url: string, options?: any) => send(url, withErrorNormalization(options))
+  }
+
+  const submit = request.submit
+  request.submit = (...submitArgs: any[]) => {
+    const optionsIndex =
+      typeof submitArgs[0] === 'string' ? 2 : submitArgs[0]?.url !== undefined ? 1 : 0
+
+    submitArgs[optionsIndex] = withErrorNormalization(submitArgs[optionsIndex])
+    return submit(...submitArgs)
+  }
+
+  return request
+}
+
+/**
+ * Creates an Inertia HTTP form.
+ *
+ * Passing a Tuyau route infers the request body and response from the route
+ * registry and binds submissions to that endpoint. The returned form keeps
+ * Inertia's state and form-management API, but exposes submit as its only
+ * endpoint-issuing method. Calls without a route retain Inertia's native
+ * useHttp signatures. AdonisJS validation errors are normalized to Inertia's
+ * field-keyed error format for each request. Must be called during component
+ * initialisation, below a TuyauProvider.
+ *
+ * @example
+ * ```ts
+ * const request = useHttp(
+ *   { route: 'users.store' },
+ *   { email: 'virk@adonisjs.com' }
+ * )
+ *
+ * await request.submit()
+ * ```
+ *
+ * @example
+ * ```ts
+ * const request = useHttp({ query: '' })
+ * await request.get('/api/users')
+ * ```
+ *
+ * @throws Error when no Tuyau client is registered on the context
+ */
+export const useHttp = useHttpImplementation as {
+  <Route extends keyof Routes>(
+    params: RouteParams<Route>,
+    data?: FormDataType<ExtractRouteBody<Route>> | (() => FormDataType<ExtractRouteBody<Route>>)
+  ): RouteHttp<Route>
+
+  <FormData extends FormDataType<FormData>, Response = unknown>(
+    method: Method | (() => Method),
+    url: string | (() => string),
+    data: FormData | (() => FormData)
+  ): ReturnType<ReturnType<typeof useInertiaHttp<FormData, Response>>['withPrecognition']>
+
+  <FormData extends FormDataType<FormData>, Response = unknown>(
+    urlMethodPair: UrlMethodPair | (() => UrlMethodPair),
+    data: FormData | (() => FormData)
+  ): ReturnType<ReturnType<typeof useInertiaHttp<FormData, Response>>['withPrecognition']>
+
+  <FormData extends FormDataType<FormData>, Response = unknown>(
+    rememberKey: string,
+    data: FormData | (() => FormData)
+  ): ReturnType<typeof useInertiaHttp<FormData, Response>>
+
+  <FormData extends FormDataType<FormData>, Response = unknown>(
+    data: (FormData & { route?: never }) | (() => FormData)
+  ): ReturnType<typeof useInertiaHttp<FormData, Response>>
+
+  <FormData extends FormDataType<FormData>, Response = unknown>(): ReturnType<
+    typeof useInertiaHttp<FormData, Response>
+  >
+}

--- a/src/client/svelte/index.ts
+++ b/src/client/svelte/index.ts
@@ -1,0 +1,27 @@
+/*
+ * @adonisjs/inertia
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+export { provideTuyau, setTuyau, tuyauContext, useTuyau } from './context.ts'
+export { useRouter } from './router.ts'
+export { useHttp, type RouteHttp } from './http.ts'
+export { default as TuyauProvider } from './tuyau_provider.svelte'
+export { default as Link } from './link.svelte'
+export { default as Form } from './form.svelte'
+export type {
+  FormActionProps,
+  FormParams,
+  FormProps,
+  FormRef,
+  FormRouteProps,
+  FormSlotProps,
+  LinkHrefProps,
+  LinkParams,
+  LinkProps,
+  LinkRouteProps,
+} from './types.ts'

--- a/src/client/svelte/internals.ts
+++ b/src/client/svelte/internals.ts
@@ -1,0 +1,22 @@
+/*
+ * @adonisjs/inertia
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Runtime surface the shipped `.svelte` wrappers import.
+ *
+ * The wrappers are published uncompiled, so their imports have to resolve
+ * against a file that exists in the built package. Funnelling them through
+ * this one module keeps that to a single extra build entrypoint instead of
+ * one per module they would otherwise reach for.
+ *
+ * Not part of the public API — consumers import from the package's `./svelte`
+ * export subpath.
+ */
+export { buildRouteUrl } from '../common.ts'
+export { setTuyau, useTuyau } from './context.ts'

--- a/src/client/svelte/link.svelte
+++ b/src/client/svelte/link.svelte
@@ -1,0 +1,79 @@
+<!--
+  @adonisjs/inertia
+
+  (c) AdonisJS
+
+  For the full copyright and license information, please view the LICENSE
+  file that was distributed with this source code.
+-->
+<!--
+  @component
+  Type-safe Link component for Inertia.js navigation.
+
+  Provides compile-time route validation and automatic parameter type
+  checking based on your application's route definitions. Automatically
+  resolves the correct URL and HTTP method for each route. Alternatively,
+  you can use the standard href prop for direct navigation.
+
+  ```svelte
+  <Link route="home">Home</Link>
+
+  <Link route="user.show" routeParams={{ id: 1 }}>View User</Link>
+
+  <Link
+    route="projects.show"
+    routeParams={{ slug: project.slug }}
+    instant
+    component="projects/show"
+    pageProps={() => ({ project })}
+  >
+    {project.title}
+  </Link>
+
+  <Link href="/about">About</Link>
+  ```
+-->
+<script lang="ts" generics="Route extends keyof Routes">
+  import { Link as InertiaLink } from '@inertiajs/svelte'
+
+  import { buildRouteUrl, useTuyau } from './internals.js'
+  import type { Routes } from '../types.ts'
+  import type { LinkProps, LinkRouteProps } from './types.ts'
+
+  const props: LinkProps<Route> = $props()
+
+  /**
+   * Read during initialisation: svelte contexts are only readable while the
+   * component is being set up, so this cannot be deferred into the derived
+   * below.
+   */
+  const tuyau = useTuyau()
+
+  /**
+   * Route-based navigation. getRoute resolves the HTTP methods and urlFor
+   * builds the URL, serializing query string parameters in one place.
+   *
+   * The href mode short-circuits: the route bindings are stripped and every
+   * remaining prop is forwarded untouched, so a plain link behaves exactly
+   * like the upstream component.
+   */
+  const resolved = $derived.by(() => {
+    const { route, routeParams, qs, method, ...linkProps } = props as LinkRouteProps<Route> & {
+      href?: string
+    }
+
+    if (linkProps.href !== undefined) {
+      return method === undefined ? linkProps : { ...linkProps, method }
+    }
+
+    const { methods } = tuyau.getRoute(route, { params: routeParams })
+
+    return {
+      ...linkProps,
+      href: buildRouteUrl(tuyau, route, routeParams, qs),
+      method: method ?? methods[0].toLowerCase(),
+    }
+  })
+</script>
+
+<InertiaLink {...resolved} />

--- a/src/client/svelte/router.ts
+++ b/src/client/svelte/router.ts
@@ -1,0 +1,28 @@
+/*
+ * @adonisjs/inertia
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { router as InertiaRouter } from '@inertiajs/svelte'
+
+import { useTuyau } from './context.ts'
+import { createRouter } from '../common.ts'
+
+/**
+ * Returns type-safe navigation utilities for Inertia.js.
+ *
+ * Provides an enhanced router with a type-safe visit method and the method
+ * sugar (get, post, put, patch, delete) that resolve route URLs, methods,
+ * and query strings from your application's route definitions.
+ * Alternatively, you can use direct href for navigation.
+ *
+ * Must be called during component initialisation, since it reads the Tuyau
+ * client from the svelte context.
+ */
+export function useRouter() {
+  return createRouter(useTuyau(), InertiaRouter)
+}

--- a/src/client/svelte/tuyau_provider.svelte
+++ b/src/client/svelte/tuyau_provider.svelte
@@ -1,0 +1,50 @@
+<!--
+  @adonisjs/inertia
+
+  (c) AdonisJS
+
+  For the full copyright and license information, please view the LICENSE
+  file that was distributed with this source code.
+-->
+<!--
+  @component
+  Provider component that makes the Tuyau client available to child components.
+
+  Wrap the part of your application that needs type-safe routing. When the
+  Inertia app is mounted without a component of your own around it, seed the
+  client through `tuyauContext` on `mount()` instead.
+
+  @example
+  ```svelte
+  <TuyauProvider client={tuyau}>
+    <App {...props} />
+  </TuyauProvider>
+  ```
+-->
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import type { Tuyau } from '@tuyau/core/client'
+  import type { TuyauRegistry } from '@tuyau/core/types'
+
+  import { setTuyau } from './internals.js'
+
+  const {
+    client,
+    children,
+  }: {
+    client: Tuyau<TuyauRegistry>
+    children?: Snippet
+  } = $props()
+
+  /**
+   * Seeds the context once with whatever client is passed in. The provider
+   * is not meant to react to `client` being swapped out for a different
+   * instance post-mount (the same contract React/Vue's TuyauProvider make
+   * implicitly, since neither re-runs its own context registration either);
+   * the compiler cannot know that statically, hence the ignore.
+   */
+  // svelte-ignore state_referenced_locally
+  setTuyau(client)
+</script>
+
+{@render children?.()}

--- a/src/client/svelte/types.ts
+++ b/src/client/svelte/types.ts
@@ -1,0 +1,194 @@
+/*
+ * @adonisjs/inertia
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import type { ComponentProps, Snippet } from 'svelte'
+import type { Form as InertiaForm, Link as InertiaLink } from '@inertiajs/svelte'
+// Inertia's declarations omit NodeNext-compatible extensions from internal type re-exports.
+// prettier-ignore
+// @ts-ignore TypeScript resolves these exports correctly in client projects using Bundler resolution.
+import type { FormComponentSlotProps, FormDataErrors, FormDataType } from '@inertiajs/core'
+import type { Prettify } from '@poppinss/utils/types'
+
+import type {
+  ExtractRouteBody,
+  InstantVisitParams,
+  KnownPages,
+  RouteParams,
+  RoutePages,
+  Routes,
+} from '../types.ts'
+
+/**
+ * Parameters required for route navigation with proper type safety. The
+ * svelte wrappers bind the route parameters under `routeParams`, matching
+ * the naming `useRouter().visit` already uses, so a single spelling covers
+ * both the components and the router within this adapter.
+ */
+export type LinkParams<Route extends keyof Routes> = RouteParams<Route>
+
+/**
+ * Props of the bundled Inertia Link component, read from the installed
+ * client so the wrapper stays in sync with it.
+ *
+ * The upstream component declares a `[key: string]: any` index signature so
+ * arbitrary element attributes pass through. `Omit` cannot remove named keys
+ * from such a type — `Exclude<string, 'href'>` is still `string` — so what
+ * survives here is the permissive index signature. That is deliberate: the
+ * route bindings intersected on top of it stay strictly checked (an explicit
+ * property always wins over an index signature), while every upstream and
+ * DOM attribute keeps flowing through untyped, exactly as it does on the
+ * upstream component.
+ */
+type InertiaLinkProps = Omit<
+  ComponentProps<typeof InertiaLink>,
+  'href' | 'method' | 'component' | 'pageProps' | 'children'
+>
+
+/**
+ * Props for the Link component when using route-based navigation. The
+ * instant-visit props are correlated with the route: `component` is limited
+ * to the pages the route's controller renders, and `pageProps` follows the
+ * chosen destination page's declared props.
+ */
+export type LinkRouteProps<Route extends keyof Routes> = InertiaLinkProps &
+  LinkParams<Route> & {
+    href?: never
+    children?: Snippet
+  } & InstantVisitParams<RoutePages<Route>>
+
+/**
+ * Props for the Link component when using direct href. There is no route to
+ * infer destination pages from, so `component` accepts any page in the page
+ * registry, with `pageProps` still correlated to the chosen page.
+ */
+export type LinkHrefProps = InertiaLinkProps & {
+  href: NonNullable<ComponentProps<typeof InertiaLink>['href']>
+  method?: ComponentProps<typeof InertiaLink>['method']
+  route?: never
+  routeParams?: never
+  qs?: never
+  children?: Snippet
+} & InstantVisitParams<KnownPages>
+
+/**
+ * Union type for Link component props - either route-based or direct href
+ */
+export type LinkProps<Route extends keyof Routes = keyof Routes> =
+  LinkRouteProps<Route> | LinkHrefProps
+
+/**
+ * Slot props received by the Form children snippet, keyed by the form-data
+ * shape. In route mode the form-data shape is the route's declared body; in
+ * action mode it stays a free-form record.
+ *
+ * Destructuring the snippet parameter inline —
+ * `{#snippet children({ errors, processing })}` — narrows from the `route`
+ * prop with no annotation. That relies on {@link FormProps} declaring
+ * `children` once, above the route/action union rather than inside each
+ * branch: svelte2tsx contextually types a snippet parameter only from a
+ * single, non-union `Snippet<...>` prop type, and a union of two `Snippet`s
+ * (or a `Snippet` reached through a union member) leaves the destructured
+ * bindings on implicit `any`. Annotate the parameter with this type when the
+ * shape cannot be inferred — action mode carries no route to derive it from.
+ */
+export type FormSlotProps<FormData extends Record<string, any> = Record<string, any>> = Omit<
+  FormComponentSlotProps<FormData>,
+  'errors'
+> & {
+  errors: Prettify<FormDataErrors<FormData>>
+}
+
+/**
+ * Instance exposed on the Form component. Svelte 5 surfaces a component's
+ * exports through `bind:this`, so this is what a `bind:this` on the wrapper
+ * resolves to: the upstream Inertia form API (submit, reset, setError, ...).
+ */
+export type FormRef<FormData extends Record<string, any> = Record<string, any>> =
+  ComponentExports<FormData>
+
+/**
+ * The upstream Form component's exports, re-keyed by the form-data shape.
+ * The bundled svelte Form is not generic over its data, so the exported API
+ * is widened here to follow the route's declared body in route mode.
+ */
+type ComponentExports<FormData extends Record<string, any>> = Omit<
+  FormSlotProps<FormData>,
+  'errors' | 'processing' | 'isDirty' | 'hasErrors' | 'wasSuccessful' | 'recentlySuccessful'
+>
+
+/**
+ * Props of the bundled Inertia Form component. As with the Link props above,
+ * the upstream index signature is what survives the `Omit`, keeping every
+ * upstream prop passing through while the wrapper-owned bindings stay typed.
+ */
+type InertiaFormProps = Omit<ComponentProps<typeof InertiaForm>, 'action' | 'method' | 'children'>
+
+/**
+ * Parameters required for route navigation with proper type safety.
+ */
+export type FormParams<Route extends keyof Routes> = RouteParams<Route>
+
+/**
+ * Route-mode bindings, without `children`. Split out from
+ * {@link FormRouteProps} so {@link FormProps} can union the two modes'
+ * bindings while declaring `children` once above them — see
+ * {@link FormSlotProps} for why the snippet has to sit outside the union.
+ */
+type FormRouteBindings<Route extends keyof Routes> = InertiaFormProps &
+  FormParams<Route> & {
+    action?: never
+  }
+
+/**
+ * Props for the Form component when using route-based navigation. The
+ * form-data shape is derived from the route's declared body type, so the
+ * children snippet follows the route without a manual generic.
+ */
+export type FormRouteProps<Route extends keyof Routes> = FormRouteBindings<Route> & {
+  children?: Snippet<[FormSlotProps<FormDataType<ExtractRouteBody<Route>>>]>
+}
+
+/**
+ * Action-mode bindings, without `children`. The action-mode counterpart of
+ * {@link FormRouteBindings}; carries no form-data generic because nothing in
+ * these bindings is keyed by it.
+ */
+type FormActionBindings = InertiaFormProps & {
+  action: NonNullable<ComponentProps<typeof InertiaForm>['action']>
+  method?: ComponentProps<typeof InertiaForm>['method']
+  route?: never
+  routeParams?: never
+  qs?: never
+}
+
+/**
+ * Props for the Form component when using a direct action
+ */
+export type FormActionProps<FormData extends Record<string, any> = Record<string, any>> =
+  FormActionBindings & {
+    children?: Snippet<[FormSlotProps<FormData>]>
+  }
+
+/**
+ * Props accepted by the Form component — either route-based or direct action.
+ *
+ * Only the *bindings* are unioned; `children` is declared once on top, which
+ * is what keeps an inline snippet's destructured parameter contextually typed
+ * (see {@link FormSlotProps}). `FormData` therefore defaults to the route's
+ * declared body rather than a free-form record, so route mode types the
+ * snippet with nothing passed. Action mode has no route to derive from and
+ * leaves the default at the union of every route body; pass `FormData`
+ * explicitly, or annotate the snippet parameter, to type it.
+ */
+export type FormProps<
+  Route extends keyof Routes = keyof Routes,
+  FormData extends Record<string, any> = FormDataType<ExtractRouteBody<Route>>,
+> = (FormRouteBindings<Route> | FormActionBindings) & {
+  children?: Snippet<[FormSlotProps<FormData>]>
+}

--- a/src/index_pages.ts
+++ b/src/index_pages.ts
@@ -16,6 +16,7 @@ import { type AllHooks } from '@adonisjs/assembler/types'
 const GLOB = {
   vue3: ['**/*.vue'],
   react: ['**/*.ts', '**/*.tsx'],
+  svelte: ['**/*.svelte'],
 }
 
 /**
@@ -45,6 +46,10 @@ type ExtractProps<T> =
     : T extends React.Component<infer Props>
       ? Prettify<Omit<Props, 'children'>>
       : never`,
+  svelte: `type ExtractProps<T> =
+  T extends (internals: never, props: infer Props) => any
+    ? Omit<Props, 'children' | '$$events' | '$$slots'>
+    : never`,
 }
 
 /**
@@ -55,7 +60,7 @@ type ExtractProps<T> =
  * type definitions that map page names to their component props.
  *
  * @param config - Configuration object specifying the frontend framework
- * @param config.framework - The frontend framework ('vue3' or 'react')
+ * @param config.framework - The frontend framework ('vue3', 'react', or 'svelte')
  * @param config.source - The path to Inertia pages (default: inertia/pages)
  * @returns Assembler hook object with run method for generating page types
  *
@@ -70,7 +75,7 @@ type ExtractProps<T> =
  * ```
  */
 export const indexPages = function (config: {
-  framework: 'vue3' | 'react'
+  framework: 'vue3' | 'react' | 'svelte'
   source?: string
 }): Extract<AllHooks['init'][number], { run: any }> {
   if (!SUPPORTED_FRAMEWORKS.includes(config.framework)) {

--- a/stubs/make/page/svelte.stub
+++ b/stubs/make/page/svelte.stub
@@ -1,0 +1,16 @@
+{{#var pageName = generators.inertiaPageName(entity.name)}}
+{{#var pageFileName = generators.inertiaPageFileName(entity.name, '.svelte')}}
+{{{
+  exports({
+    to: app.makePath(pagesDir, entity.path, pageFileName)
+  })
+}}}
+<script lang="ts">
+  import { type Data } from '@generated/data'
+
+  let {}: {} = $props()
+</script>
+
+<div>
+  <h1>{{ pageName }}</h1>
+</div>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,0 +1,6 @@
+/**
+ * Consumed by svelte-check and the svelte language tools. The package ships
+ * uncompiled `.svelte` wrappers and uses no preprocessors, so the config only
+ * needs to exist for the tooling to pick the project up.
+ */
+export default {}

--- a/tests/commands/make_page.spec.ts
+++ b/tests/commands/make_page.spec.ts
@@ -42,6 +42,20 @@ test.group('MakePage', () => {
     )
   })
 
+  test('create a svelte page using --svelte flag', async ({ assert, fs }) => {
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+    await ace.app.init()
+    ace.ui.switchMode('raw')
+
+    const command = await ace.create(MakePage, ['home', '--svelte'])
+    await command.exec()
+
+    command.assertSucceeded()
+    command.assertLog('green(DONE:)    create inertia/pages/home.svelte')
+    await assert.fileContains('inertia/pages/home.svelte', '<script lang="ts">')
+    await assert.fileContains('inertia/pages/home.svelte', 'Home')
+  })
+
   test('create a page inside a nested directory', async ({ assert, fs }) => {
     const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
     await ace.app.init()
@@ -81,6 +95,20 @@ test.group('MakePage', () => {
 
     command.assertSucceeded()
     command.assertLog('green(DONE:)    create inertia/pages/home.tsx')
+  })
+
+  test('auto-detect svelte from existing pages', async ({ fs }) => {
+    await fs.create('inertia/pages/dashboard.svelte', '<h1>Dashboard</h1>')
+
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+    await ace.app.init()
+    ace.ui.switchMode('raw')
+
+    const command = await ace.create(MakePage, ['home'])
+    await command.exec()
+
+    command.assertSucceeded()
+    command.assertLog('green(DONE:)    create inertia/pages/home.svelte')
   })
 
   test('prompt when framework cannot be detected', async ({ fs }) => {
@@ -124,5 +152,19 @@ test.group('MakePage', () => {
 
     command.assertSucceeded()
     command.assertLog('green(DONE:)    create inertia/pages/home.tsx')
+  })
+
+  test('flags take priority over auto-detection for svelte', async ({ fs }) => {
+    await fs.create('inertia/pages/dashboard.vue', '<template></template>')
+
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+    await ace.app.init()
+    ace.ui.switchMode('raw')
+
+    const command = await ace.create(MakePage, ['home', '--svelte'])
+    await command.exec()
+
+    command.assertSucceeded()
+    command.assertLog('green(DONE:)    create inertia/pages/home.svelte')
   })
 })

--- a/tests/index_pages.spec.ts
+++ b/tests/index_pages.spec.ts
@@ -147,6 +147,82 @@ test.group('Index pages', () => {
     )
   })
 
+  test('index svelte pages', async ({ assert, fs }) => {
+    const cliUi = Kernel.create().ui
+    cliUi.switchMode('raw')
+
+    await fs.create('inertia/pages/users/index.svelte', '')
+    await fs.create('inertia/pages/users/create.svelte', '')
+    await fs.create('inertia/pages/home.svelte', '')
+
+    const generator = new IndexGenerator(stringHelpers.toUnixSlash(fs.basePath), cliUi.logger)
+    const indexer = indexPages({
+      framework: 'svelte',
+    })
+
+    indexer.run({} as any, {} as any, generator)
+    await generator.generate()
+
+    await assert.fileExists('.adonisjs/server/pages.d.ts')
+    await assert.fileContains('.adonisjs/server/pages.d.ts', [
+      `type ExtractProps<T>`,
+      `declare module '@adonisjs/inertia/types' {`,
+      `export interface InertiaPages {`,
+      `'home': ExtractProps<(typeof import('../../inertia/pages/home.svelte'))['default']>`,
+      `'users/create': ExtractProps<(typeof import('../../inertia/pages/users/create.svelte'))['default']>`,
+      `'users/index': ExtractProps<(typeof import('../../inertia/pages/users/index.svelte'))['default']>`,
+      ``,
+    ])
+    assert.isDefined(
+      cliUi.logger.getLogs().find(({ message }) => message.includes('codegen: created 1 file(s)'))
+    )
+  })
+
+  /**
+   * Guards the specific regression the structural helper exists for: svelte's
+   * own `ComponentProps<T>` collapses page props to `never` under
+   * svelte-check, so the generated file must not reach for it.
+   */
+  test('svelte page props are extracted structurally, not through ComponentProps', async ({
+    assert,
+    fs,
+  }) => {
+    const cliUi = Kernel.create().ui
+    cliUi.switchMode('raw')
+
+    await fs.create('inertia/pages/home.svelte', '')
+
+    const generator = new IndexGenerator(stringHelpers.toUnixSlash(fs.basePath), cliUi.logger)
+    indexPages({ framework: 'svelte' }).run({} as any, {} as any, generator)
+    await generator.generate()
+
+    const contents = await fs.contents('.adonisjs/server/pages.d.ts')
+
+    assert.notInclude(contents, 'ComponentProps')
+    assert.include(contents, `T extends (internals: never, props: infer Props) => any`)
+    assert.include(contents, `Omit<Props, 'children' | '$$events' | '$$slots'>`)
+  })
+
+  test('index custom svelte pages source', async ({ assert, fs }) => {
+    const cliUi = Kernel.create().ui
+    cliUi.switchMode('raw')
+
+    await fs.create('resources/js/pages/home.svelte', '')
+
+    const generator = new IndexGenerator(stringHelpers.toUnixSlash(fs.basePath), cliUi.logger)
+    const indexer = indexPages({
+      framework: 'svelte',
+      source: 'resources/js/pages',
+    })
+
+    indexer.run({} as any, {} as any, generator)
+    await generator.generate()
+
+    await assert.fileContains('.adonisjs/server/pages.d.ts', [
+      `'home': ExtractProps<(typeof import('../../resources/js/pages/home.svelte'))['default']>`,
+    ])
+  })
+
   test('throw error when unsupported framework is defined for indexing pages', async ({ fs }) => {
     const cliUi = Kernel.create().ui
     cliUi.switchMode('raw')
@@ -163,5 +239,7 @@ test.group('Index pages', () => {
 
     indexer.run({} as any, {} as any, generator)
     await generator.generate()
-  }).throws('Unsupported framework "solid". Types generation is available only for vue3,react')
+  }).throws(
+    'Unsupported framework "solid". Types generation is available only for vue3,react,svelte'
+  )
 })

--- a/tests/support/register_svelte_loader.mjs
+++ b/tests/support/register_svelte_loader.mjs
@@ -1,0 +1,12 @@
+/*
+ * @adonisjs/inertia
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { register } from 'node:module'
+
+register('./svelte_loader.mjs', import.meta.url)

--- a/tests/support/svelte_loader.mjs
+++ b/tests/support/svelte_loader.mjs
@@ -1,0 +1,115 @@
+/*
+ * @adonisjs/inertia
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Node ESM loader hook that compiles `.svelte` files on the fly for the test
+ * suite, via `svelte/compiler`'s `compile()` directly (server output, since
+ * tests run in Node, not a browser).
+ *
+ * This is test-only infrastructure, not something the shipped package needs:
+ * the built package ships `.svelte` files uncompiled on purpose (see
+ * tsdown.config.ts), and a real consuming app's own Vite + svelte plugin
+ * compiles them at that app's build time. This loader exists purely so
+ * tests/svelte_components.spec.ts can import the wrapper components
+ * directly under plain Node (via `node --import=@poppinss/ts-exec`, which
+ * has no idea how to parse `.svelte` syntax on its own) without requiring a
+ * full app/Vite harness just to prove the components render.
+ */
+import { compile, compileModule } from 'svelte/compiler'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * `@inertiajs/svelte`'s own published `dist/index.js` re-exports some of its
+ * internals with extensionless relative specifiers (e.g. `from
+ * './components/createForm'`), which only resolves through a bundler's
+ * auto-extension resolution (Vite, which every real Svelte app builds with).
+ * Plain Node ESM requires the exact extension. This adds exactly that one
+ * fallback — retry a failed relative resolution with a handful of common
+ * extensions — scoped to resolution failures only, so it changes nothing for
+ * specifiers that already resolve.
+ */
+const FALLBACK_EXTENSIONS = ['.js', '/index.js']
+
+export async function resolve(specifier, context, nextResolve) {
+  try {
+    return await nextResolve(specifier, context)
+  } catch (error) {
+    const isRelative =
+      specifier === '.' ||
+      specifier === '..' ||
+      specifier.startsWith('./') ||
+      specifier.startsWith('../')
+    if (!isRelative) {
+      throw error
+    }
+
+    // Directory import (e.g. `from '..'`): Node's error carries the resolved
+    // directory URL, so retry that exact directory's index.js rather than
+    // guessing a path by string-concatenating the original specifier.
+    if (error?.code === 'ERR_UNSUPPORTED_DIR_IMPORT' && error?.url) {
+      try {
+        return await nextResolve(`${error.url}index.js`, context)
+      } catch {
+        throw error
+      }
+    }
+
+    if (error?.code === 'ERR_MODULE_NOT_FOUND') {
+      for (const ext of FALLBACK_EXTENSIONS) {
+        try {
+          return await nextResolve(`${specifier}${ext}`, context)
+        } catch {
+          continue
+        }
+      }
+    }
+
+    throw error
+  }
+}
+
+export async function load(url, context, nextLoad) {
+  if (url.endsWith('.svelte')) {
+    const filename = fileURLToPath(url)
+    const source = await readFile(filename, 'utf-8')
+    const { js } = compile(source, {
+      filename,
+      generate: 'server',
+      css: 'injected',
+    })
+
+    return {
+      format: 'module',
+      source: js.code,
+      shortCircuit: true,
+    }
+  }
+
+  /**
+   * Svelte 5 "universal reactivity" modules (`*.svelte.js` / `*.svelte.ts`)
+   * use rune syntax (`$state`, `$derived`, ...) outside a component, which is
+   * not valid JavaScript until compiled with `compileModule` — a separate
+   * entrypoint from `compile` (components) in `svelte/compiler`.
+   * `@inertiajs/svelte` ships several of these (page/useForm/useHttp/...).
+   */
+  if (url.endsWith('.svelte.js') || url.endsWith('.svelte.ts')) {
+    const filename = fileURLToPath(url)
+    const source = await readFile(filename, 'utf-8')
+    const { js } = compileModule(source, { filename, generate: 'server' })
+
+    return {
+      format: 'module',
+      source: js.code,
+      shortCircuit: true,
+    }
+  }
+
+  return nextLoad(url, context)
+}

--- a/tests/svelte_components.spec.ts
+++ b/tests/svelte_components.spec.ts
@@ -1,0 +1,242 @@
+/*
+ * @adonisjs/inertia
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Runtime counterpart to react_components.spec.ts, adapted to how Svelte
+ * actually invokes components. `React.createElement`/Vue's `h()` only build
+ * a lazy element/vnode descriptor — the component function itself is not
+ * called until something mounts the tree, so those tests mostly prove the
+ * call *compiles*. Svelte 5 has no such descriptor: `mount`/`render` invoke
+ * the component immediately. `render` from `svelte/server` is used here
+ * (no DOM/jsdom dependency) so these assertions are a genuine step further —
+ * they prove the wrapper actually resolves the route and renders real HTML
+ * through the bundled `@inertiajs/svelte` components, not just that
+ * construction doesn't throw synchronously.
+ *
+ * Requires the test-only `.svelte` Node loader (tests/support/svelte_loader)
+ * registered by bin/test.ts — see that file and the loader's own doc comment
+ * for why plain Node needs it and what it works around.
+ *
+ * Scope note: an earlier draft of this file also asserted that rendering
+ * Link outside a TuyauProvider throws. In isolation it does (verified
+ * directly), but reproducibly stopped throwing once several successful
+ * `render()` calls preceded it in the same process — an SSR context-reuse
+ * quirk in `svelte/server`/`@inertiajs/svelte` under rapid sequential calls,
+ * not in this adapter's own code (which unconditionally calls `useTuyau()`
+ * at component init either way). Real apps render one page per request
+ * through `@inertiajs/svelte`'s own `createInertiaApp` SSR pipeline, not this
+ * raw harness, so it was dropped rather than chased further here.
+ */
+import { render } from 'svelte/server'
+import { test } from '@japa/runner'
+import { createTuyau } from '@tuyau/core/client'
+import { type AdonisEndpoint } from '@tuyau/core/types'
+
+import Link from '../src/client/svelte/link.svelte'
+import Form from '../src/client/svelte/form.svelte'
+import { provideTuyau, tuyauContext } from '../src/client/svelte/context.ts'
+
+const routes = {
+  'users.index': {
+    methods: ['GET', 'HEAD'],
+    pattern: '/users',
+    tokens: [{ old: '/users', type: 0, val: 'users', end: '' }],
+    types: null as any as {
+      body: {}
+      paramsTuple: []
+      params: {}
+      query: {}
+      response: unknown
+    },
+  },
+  'users.store': {
+    methods: ['POST'],
+    pattern: '/users',
+    tokens: [{ old: '/users', type: 0, val: 'users', end: '' }],
+    types: null as any as {
+      body: {}
+      paramsTuple: []
+      params: {}
+      query: {}
+      response: unknown
+    },
+  },
+  'users.show': {
+    methods: ['GET', 'HEAD'],
+    pattern: '/users/:id',
+    tokens: [
+      { old: '/users', type: 0, val: 'users', end: '' },
+      { old: ':id', type: 1, val: 'id', end: '' },
+    ],
+    types: null as any as {
+      body: {}
+      paramsTuple: [string]
+      params: { id: string }
+      query: {}
+      response: unknown
+    },
+  },
+  'users.update': {
+    methods: ['PUT', 'PATCH'],
+    pattern: '/users/:id',
+    tokens: [
+      { old: '/users', type: 0, val: 'users', end: '' },
+      { old: ':id', type: 1, val: 'id', end: '' },
+    ],
+    types: null as any as {
+      body: {}
+      paramsTuple: [string]
+      params: { id: string }
+      query: {}
+      response: unknown
+    },
+  },
+} as const satisfies Record<string, AdonisEndpoint>
+
+const registry = {
+  routes,
+  $tree: {} as any,
+}
+
+test.group('Svelte | Link Component', () => {
+  test('Link with route renders the resolved href', ({ assert }) => {
+    const client = createTuyau({ registry, baseUrl: 'http://localhost' })
+
+    const { body } = render(Link as any, {
+      props: { route: 'users.index' },
+      context: tuyauContext(client),
+    })
+
+    assert.include(body, 'href="/users"')
+  })
+
+  test('Link with route and params renders the resolved href', ({ assert }) => {
+    const client = createTuyau({ registry, baseUrl: 'http://localhost' })
+
+    const { body } = render(Link as any, {
+      props: { route: 'users.show', routeParams: { id: '1' } },
+      context: tuyauContext(client),
+    })
+
+    assert.include(body, 'href="/users/1"')
+  })
+
+  test('Link with direct href does not throw', ({ assert }) => {
+    const client = createTuyau({ registry, baseUrl: 'http://localhost' })
+
+    assert.doesNotThrow(() => {
+      render(Link as any, { props: { href: '/about' }, context: tuyauContext(client) })
+    })
+  })
+
+  test('Link with href and a non-GET method renders a JS-driven button', ({ assert }) => {
+    const client = createTuyau({ registry, baseUrl: 'http://localhost' })
+
+    // Non-GET methods can't navigate via a plain <a href>, so the bundled
+    // Inertia Link renders a button that drives the visit via JS instead —
+    // real upstream behavior, not something this wrapper changes. This
+    // proves `method` reaches the underlying component correctly.
+    const { body } = render(Link as any, {
+      props: { href: '/logout', method: 'post' },
+      context: tuyauContext(client),
+    })
+
+    assert.include(body, '<button type="button">')
+  })
+})
+
+test.group('Svelte | Form Component', () => {
+  test('Form with route renders the resolved action and method', ({ assert }) => {
+    const client = createTuyau({ registry, baseUrl: 'http://localhost' })
+
+    const { body } = render(Form as any, {
+      props: { route: 'users.store' },
+      context: tuyauContext(client),
+    })
+
+    assert.include(body, 'action="/users"')
+    assert.include(body, 'method="post"')
+  })
+
+  test('Form with route and params renders the resolved action', ({ assert }) => {
+    const client = createTuyau({ registry, baseUrl: 'http://localhost' })
+
+    const { body } = render(Form as any, {
+      props: { route: 'users.show', routeParams: { id: '1' } },
+      context: tuyauContext(client),
+    })
+
+    assert.include(body, 'action="/users/1"')
+  })
+
+  test('Form with direct action does not throw', ({ assert }) => {
+    const client = createTuyau({ registry, baseUrl: 'http://localhost' })
+
+    assert.doesNotThrow(() => {
+      render(Form as any, {
+        props: { action: { url: '/users', method: 'post' } },
+        context: tuyauContext(client),
+      })
+    })
+  })
+
+  test('Form with action using PUT method renders a hidden method override', ({ assert }) => {
+    const client = createTuyau({ registry, baseUrl: 'http://localhost' })
+
+    const { body } = render(Form as any, {
+      props: { action: { url: '/users/1', method: 'put' } },
+      context: tuyauContext(client),
+    })
+
+    assert.include(body, 'action="/users/1"')
+  })
+})
+
+test.group('Svelte | Tuyau context', () => {
+  /**
+   * `provideTuyau` is what an app actually uses: `createInertiaApp` owns the
+   * mounting (so it can hydrate server-rendered markup or mount from scratch)
+   * and hands a context map to its `withApp` hook rather than accepting one
+   * back. Seeding through that map has to reach the components the same way
+   * `tuyauContext` does — the two write the same key, and this proves it
+   * rather than assuming it.
+   */
+  test('a client seeded the way withApp seeds it reaches the components', ({ assert }) => {
+    const client = createTuyau({ registry, baseUrl: 'http://localhost' })
+
+    const context = new Map<any, any>()
+    provideTuyau(context, client)
+
+    const { body } = render(Link as any, {
+      props: { route: 'users.show', routeParams: { id: '1' } },
+      context,
+    })
+
+    assert.include(body, 'href="/users/1"')
+  })
+
+  test('provideTuyau and tuyauContext agree on the context key', ({ assert }) => {
+    const client = createTuyau({ registry, baseUrl: 'http://localhost' })
+
+    const seeded = new Map<any, any>()
+    provideTuyau(seeded, client)
+
+    assert.deepEqual([...seeded.keys()], [...tuyauContext(client).keys()])
+  })
+
+  test('provideTuyau leaves the rest of the context map alone', ({ assert }) => {
+    const client = createTuyau({ registry, baseUrl: 'http://localhost' })
+
+    const context = new Map<any, any>([['app.locale', 'en']])
+    provideTuyau(context, client)
+
+    assert.equal(context.get('app.locale'), 'en')
+    assert.equal(context.size, 2)
+  })
+})

--- a/tests/types/svelte/probe.svelte
+++ b/tests/types/svelte/probe.svelte
@@ -1,0 +1,68 @@
+<!--
+  Bundler-resolution smoke fixture for the svelte adapter, checked by
+  svelte-check via ./tsconfig.json. Exercises real markup usage (route
+  resolution, snippets, instant-visit props) that a plain .ts assertion
+  cannot: whether the .svelte wrappers actually compile against genuine
+  Inertia/Tuyau markup, not just their exported types.
+
+  Negative (should-error) assertions live in ./type_assertions.spec.ts
+  instead of here: svelte-check does not honor `@ts-expect-error` placed as
+  an HTML comment in markup (verified — the diagnostic still surfaces), so
+  "this must fail to compile" cases are checked as plain TS statements in a
+  <script> block there, where `@ts-expect-error` works normally.
+-->
+<script lang="ts">
+  import { Link, Form } from '../../../src/client/svelte/index.ts'
+  import type { FormSlotProps } from '../../../src/client/svelte/types.ts'
+</script>
+
+<Link route="users.show" routeParams={{ id: '1' }}>View user</Link>
+<Link route="users.index" qs={{ page: 2 }}>All users</Link>
+<Link href="/about">About</Link>
+<Link href="/logout" method="post">Logout</Link>
+<Link
+  route="users.show"
+  routeParams={{ id: '1' }}
+  instant
+  component="users/show"
+  pageProps={() => ({ user: { id: 1 } })}
+>
+  Instant visit
+</Link>
+
+<!--
+  Route mode with a bare, unannotated snippet parameter: the destructured
+  bindings must narrow from the `route` prop alone. `getData().email` and
+  `reset('email')` are read here on purpose — they only compile if the
+  form-data shape resolved to `users.store`'s declared body rather than to a
+  free-form record or the union of every route body.
+-->
+<Form route="users.store">
+  {#snippet children({ errors, processing, getData, reset })}
+    <input type="text" name="email" value={getData().email} />
+    {#if errors.email}<div>{errors.email}</div>{/if}
+    <button type="submit" disabled={processing}>Create</button>
+    <button type="button" onclick={() => reset('email', 'remember')}>Reset</button>
+  {/snippet}
+</Form>
+
+<!--
+  Route mode on a route with a different body, so a single fixture cannot
+  pass by accident against one shared shape.
+-->
+<Form route="posts.update" routeParams={{ id: '1' }}>
+  {#snippet children({ errors, getData })}
+    <input type="text" name="title" value={getData().title} />
+    {#if errors.title}<div>{errors.title}</div>{/if}
+  {/snippet}
+</Form>
+
+<!--
+  Action mode carries no route to derive the form-data shape from, so the
+  snippet parameter is annotated — the documented path for this mode.
+-->
+<Form action={{ url: '/users', method: 'post' }}>
+  {#snippet children({ processing }: FormSlotProps<{ email: string }>)}
+    <button type="submit" disabled={processing}>Create</button>
+  {/snippet}
+</Form>

--- a/tests/types/svelte/registry.ts
+++ b/tests/types/svelte/registry.ts
@@ -1,0 +1,126 @@
+/*
+ * @adonisjs/inertia
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { type AdonisEndpoint } from '@tuyau/core/types'
+
+import type { PageObject } from '../../../src/types.ts'
+
+/**
+ * Page registry fixture for the instant-visit assertions. Augmented here
+ * rather than in a fixture so every file in the svelte typecheck program
+ * sees the same pages.
+ */
+declare module '../../../src/types.ts' {
+  interface InertiaPages {
+    'users/index': { users: { id: number }[] }
+    'users/show': { user: { id: number } }
+    'users/limited': { reason: string }
+    'posts/index': { posts?: string[] }
+  }
+}
+
+export const routes = {
+  'users.index': {
+    methods: ['GET', 'HEAD'],
+    pattern: '/users',
+    tokens: [{ old: '/users', type: 0, val: 'users', end: '' }],
+    types: null as any as {
+      body: {}
+      paramsTuple: []
+      params: {}
+      query: {}
+      response: string | PageObject<{ users: { id: number }[] }, 'users/index'>
+    },
+  },
+  'users.show': {
+    methods: ['GET', 'HEAD'],
+    pattern: '/users/:id',
+    tokens: [
+      { old: '/users', type: 0, val: 'users', end: '/' },
+      { old: ':id', type: 1, val: 'id', end: '' },
+    ],
+    types: null as any as {
+      body: {}
+      paramsTuple: [string]
+      params: { id: string }
+      query: {}
+      response:
+        | string
+        | PageObject<{ user: { id: number } }, 'users/show'>
+        | PageObject<{ reason: string }, 'users/limited'>
+    },
+  },
+  'users.comments.edit': {
+    methods: ['GET', 'HEAD'],
+    pattern: '/users/:id/comments/:comment_id/edit',
+    tokens: [
+      { old: '/users', type: 0, val: 'users', end: '/' },
+      { old: ':id', type: 1, val: 'id', end: '/' },
+      { old: '/comments', type: 0, val: 'comments', end: '/' },
+      { old: ':comment_id', type: 1, val: 'comment_id', end: '/edit' },
+      { old: '/edit', type: 0, val: 'edit', end: '' },
+    ],
+    types: null as any as {
+      body: {}
+      paramsTuple: [string, string]
+      params: { id: string; comment_id: string }
+      query: {}
+      response: unknown
+    },
+  },
+  'posts.index': {
+    methods: ['GET', 'HEAD'],
+    pattern: '/posts',
+    tokens: [{ old: '/posts', type: 0, val: 'posts', end: '' }],
+    types: null as any as {
+      body: {}
+      paramsTuple: []
+      params: {}
+      query: { page?: number; status?: string }
+      response: string | PageObject<{ posts?: string[] }, 'posts/index'>
+    },
+  },
+  'users.store': {
+    methods: ['POST'],
+    pattern: '/users',
+    tokens: [{ old: '/users', type: 0, val: 'users', end: '' }],
+    types: null as any as {
+      body: { email: string; remember?: boolean }
+      paramsTuple: []
+      params: {}
+      query: {}
+      response: { id: number; email: string }
+    },
+  },
+  'posts.update': {
+    methods: ['PUT', 'PATCH'],
+    pattern: '/posts/:id',
+    tokens: [
+      { old: '/posts', type: 0, val: 'posts', end: '/' },
+      { old: ':id', type: 1, val: 'id', end: '' },
+    ],
+    types: null as any as {
+      body: { title: string }
+      paramsTuple: [string]
+      params: { id: string }
+      query: {}
+      response: unknown
+    },
+  },
+} as const satisfies Record<string, AdonisEndpoint>
+
+export const registry = {
+  routes,
+  $tree: {} as any,
+}
+
+declare module '@tuyau/core/types' {
+  type Registry = typeof registry
+  export interface UserRegistry extends Registry {}
+}

--- a/tests/types/svelte/tsconfig.json
+++ b/tests/types/svelte/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  /**
+   * Client-resolution typecheck program for the svelte adapter, run with
+   * svelte-check so the `.svelte` wrappers are checked alongside the fixtures
+   * that consume them.
+   *
+   * The svelte adapter cannot live in the package's NodeNext program: it
+   * imports `.svelte` modules, and `@inertiajs/svelte` publishes its runtime
+   * only under the `svelte` export condition. Both resolve here, under
+   * Bundler resolution with the DOM lib. Living at
+   * tests/types/svelte/tsconfig.json, this is also the nearest config the
+   * editor's TS server discovers for these files.
+   */
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "types": []
+  },
+  "include": ["../../../src/client/svelte/**/*", "./**/*"],
+  /**
+   * Reset the inherited exclude so the svelte sources, which the package
+   * program deliberately skips, are not filtered back out of this program.
+   */
+  "exclude": []
+}

--- a/tests/types/svelte/type_assertions.spec.ts
+++ b/tests/types/svelte/type_assertions.spec.ts
@@ -1,0 +1,156 @@
+/*
+ * @adonisjs/inertia
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Type-only "should fail to compile" assertions for the svelte adapter.
+ *
+ * These live as plain TypeScript in a <script>-less .spec.ts file rather than
+ * inside probe.svelte: svelte-check does not honor `@ts-expect-error` placed
+ * as an HTML comment in markup (verified empirically — the diagnostic still
+ * surfaces at the annotated line), so route-specific prop shapes are asserted
+ * directly via the adapter's own exported `LinkRouteProps<Route>` /
+ * `FormRouteProps<Route>` generics instead of instantiating a component in a
+ * template. probe.svelte in this same folder covers the positive ("this must
+ * compile and render") side under real markup, where Svelte's generic
+ * inference narrows `Route` from the literal `route="..."` prop the same way
+ * it does here from the explicit type argument.
+ *
+ * `ComponentProps<typeof Link>` (no type argument) is deliberately not used
+ * for these: without a concrete `Route`, it resolves `Link`'s generic to its
+ * unconstrained default (the union of every route name), which collapses
+ * per-route requirements like "routeParams is mandatory for this route" into
+ * "optional across the union" and silently defeats exactly the checks below.
+ *
+ * Runtime: these are ordinary object/variable declarations, so at test-run
+ * time (via bin/test.ts) every assignment below just executes harmlessly;
+ * the assertions only bite under a real typecheck
+ * (svelte-check --tsconfig tests/types/svelte/tsconfig.json), where an
+ * `@ts-expect-error` line that does *not* error becomes an "unused directive"
+ * compile error, and a line that errors without the comment fails normally.
+ * `@ts-expect-error` only covers the line immediately below it, so within a
+ * multi-line object literal it sits directly above the offending property,
+ * not above the statement.
+ */
+import { test } from '@japa/runner'
+
+import type { FormRouteProps, LinkRouteProps } from '../../../src/client/svelte/types.ts'
+import './registry.ts'
+
+test.group('Svelte | Link Component types', () => {
+  test('route-based props type-check', () => {
+    const valid: LinkRouteProps<'users.show'> = { route: 'users.show', routeParams: { id: '1' } }
+    void valid
+
+    // @ts-expect-error missing required params
+    const missingParams: LinkRouteProps<'users.show'> = { route: 'users.show' }
+    void missingParams
+
+    const badQs: LinkRouteProps<'posts.index'> = {
+      route: 'posts.index',
+      // @ts-expect-error unknown query key for a route with declared query types
+      qs: { unknownKey: true },
+    }
+    void badQs
+
+    const badQsValue: LinkRouteProps<'posts.index'> = {
+      route: 'posts.index',
+      // @ts-expect-error wrong value type for a declared query param
+      qs: { page: 'two' },
+    }
+    void badQsValue
+
+    const mixed: LinkRouteProps<'users.show'> = {
+      route: 'users.show',
+      routeParams: { id: '1' },
+      // @ts-expect-error cannot mix route and href
+      href: '/x',
+    }
+    void mixed
+  })
+
+  test('instant-visit pageProps follow the correlated route', () => {
+    const instantOk: LinkRouteProps<'users.show'> = {
+      route: 'users.show',
+      routeParams: { id: '1' },
+      instant: true,
+      component: 'users/show',
+      pageProps: () => ({ user: { id: 1 } }),
+    }
+    void instantOk
+
+    const instantOnPageWithNoRequiredProps: LinkRouteProps<'posts.index'> = {
+      route: 'posts.index',
+      instant: true,
+      component: 'posts/index',
+    }
+    void instantOnPageWithNoRequiredProps
+
+    const wrongPage: LinkRouteProps<'users.show'> = {
+      route: 'users.show',
+      routeParams: { id: '1' },
+      instant: true,
+      // @ts-expect-error page not rendered by this route
+      component: 'posts/index',
+      // @ts-expect-error pageProps follows the (wrong) page above
+      pageProps: () => ({}),
+    }
+    void wrongPage
+
+    const typoPage: LinkRouteProps<'users.show'> = {
+      route: 'users.show',
+      routeParams: { id: '1' },
+      instant: true,
+      // @ts-expect-error misspelled page name
+      component: 'users/shwo',
+      pageProps: () => ({ user: { id: 1 } }),
+    }
+    void typoPage
+  })
+})
+
+test.group('Svelte | Form Component types', () => {
+  test('route-based props type-check', () => {
+    const valid: FormRouteProps<'users.store'> = { route: 'users.store' }
+    void valid
+
+    // @ts-expect-error missing required params
+    const missingParams: FormRouteProps<'users.comments.edit'> = { route: 'users.comments.edit' }
+    void missingParams
+
+    const withParams: FormRouteProps<'users.comments.edit'> = {
+      route: 'users.comments.edit',
+      routeParams: { id: '1', comment_id: '2' },
+    }
+    void withParams
+
+    const mixed: FormRouteProps<'users.store'> = {
+      route: 'users.store',
+      // @ts-expect-error cannot mix route and action
+      action: { url: '/x', method: 'post' },
+    }
+    void mixed
+
+    const validChildren: FormRouteProps<'users.store'> = {
+      route: 'users.store',
+      children: ({ errors, getData, reset }) => {
+        errors.email
+        getData().email
+        reset('email', 'remember')
+
+        // @ts-expect-error unknown route body field
+        errors.unknown
+
+        return undefined as unknown as ReturnType<
+          NonNullable<FormRouteProps<'users.store'>['children']>
+        >
+      },
+    }
+    void validChildren
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,19 @@
    * where the upstream Inertia declaration files resolve. They are excluded
    * here and checked by the tests/types/tsconfig.json program, which the
    * editor also discovers as the nearest config for those files.
+   *
+   * The svelte adapter is excluded wholesale (source and its type-test
+   * program), not just its fixtures: `@inertiajs/svelte` publishes its
+   * runtime only under the `svelte` export condition (no `import`/`default`
+   * fallback), which this package's NodeNext program cannot match. Unlike
+   * the react/vue wrappers (plain `.ts`, `h()`-based), the svelte wrappers
+   * are also genuine `.svelte` SFCs with no render-function escape hatch, so
+   * the whole `src/client/svelte` tree lives exclusively under Bundler
+   * resolution at tests/types/svelte/tsconfig.json, run with svelte-check.
+   * `tests/types/svelte/**` is excluded here for the same reason
+   * `react_client.spec.ts`/`vue_client.spec.ts` are: it's checked by that
+   * program, and its `registry.ts` augmentation would otherwise collide with
+   * react.spec.ts's identically-named local `Registry` type in this program.
    */
   "exclude": [
     "node_modules",
@@ -17,6 +30,8 @@
     "tests/types/react_client.spec.ts",
     "tests/types/vue_client.spec.ts",
     "tests/types/react_form.fixture.tsx",
-    "tests/types/vue_form.fixture.vue"
+    "tests/types/vue_form.fixture.vue",
+    "src/client/svelte/**/*",
+    "tests/types/svelte/**/*"
   ]
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
     './src/plugins/japa/api_client.ts',
     './src/client/react/index.tsx',
     './src/client/vue/index.ts',
+    './src/client/svelte/index.ts',
+    './src/client/svelte/internals.ts',
     './commands/make_page.ts',
   ],
   outDir: './build',
@@ -27,5 +29,19 @@ export default defineConfig({
     transform: {
       jsx: 'react-jsx',
     },
+  },
+  /**
+   * `.svelte` imports inside src/client/svelte are left untouched rather than
+   * compiled: unlike the vue wrappers (plain `.ts`, built on `h()`), svelte
+   * has no render-function escape hatch, so the wrappers are genuine `.svelte`
+   * SFCs. They ship uncompiled — `copy:svelte` (package.json) copies the raw
+   * files alongside the compiled `index.js` — and the consuming app's own
+   * Vite + svelte plugin compiles them, exactly how Svelte component
+   * libraries are conventionally published. Compiling them here would bake in
+   * a client- or server-only build and fight the app's own dev/prod, CSR/SSR
+   * split.
+   */
+  deps: {
+    neverBundle: [/\.svelte$/],
   },
 })


### PR DESCRIPTION
### 🔗 Linked issue

Related discussion: [#5095](https://github.com/orgs/adonisjs/discussions/5095)

### ❓ Type of change

* [ ] 🐞 Bug fix
* [ ] 👌 Enhancement
* [x] ✨ New feature
* [ ] ⚠️ Breaking change

### 📚 Description

This PR adds a first-party Svelte client adapter, exported from `@adonisjs/inertia/svelte`.

The goal is to give Svelte apps the same Tuyau-typed client API that React and Vue already have.

Existing React/Vue users should not be affected. `svelte` and `@inertiajs/svelte` are optional peer dependencies, and the new implementation is only exposed through the new `svelte` export.

### What's included

| Area           | Change                                                                                                                                                                 |
| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Client adapter | Added `src/client/svelte/` with `Link`, `Form`, `TuyauProvider`, `useRouter`, `useHttp`, `useTuyau`, `setTuyau`, `provideTuyau`, `tuyauContext`, and the related types |
| Scaffolding    | Added `make:page --svelte`, `.svelte` page auto-detection, Svelte framework option, and `stubs/make/page/svelte.stub`                                                  |
| Assembler      | Added `indexPages({ framework: 'svelte' })`, including the `**/*.svelte` glob and Svelte-specific `ExtractProps`                                                       |
| Build          | Added `copy:svelte`, `emit:svelte-dts`, and two tsdown entrypoints                                                                                                     |
| Tests          | Added Svelte component tests, type tests, and new `make:page` / `indexPages` cases                                                                                     |

The adapters share the existing common helpers for route props and validation errors, so Svelte follows the same behaviour as React and Vue.

### Svelte-specific parts

There are a few places where Svelte works differently from the existing adapters. These are probably the areas that need the most review.

1. **Svelte components are shipped uncompiled**

`Link` and `Form` are actual `.svelte` files, so they can't be implemented the same way as the Vue wrappers.

The files are copied to `build/` and left for the consuming app's Vite/Svelte plugin to compile. They're also excluded from the bundle with `deps.neverBundle`.

This keeps the Svelte compilation in the consuming app, which should also work better with its own CSR/SSR setup.

2. **`internals.ts`**

The shipped `.svelte` files need a runtime module to import from. `src/client/svelte/internals.ts` gives them a single built entrypoint instead of having each wrapper depend on a separate module.

3. **Shared context key**

The context uses `Symbol.for('Tuyau')` instead of `Symbol()`.

Because the uncompiled Svelte wrappers and the package export can end up resolving the context module through different entrypoints, there can be more than one instance of that module. Using `Symbol.for` keeps those instances on the same context key.

4. **Installing the context with `withApp`**

Svelte doesn't have a component wrapping the root of an Inertia app, so the context is installed through `createInertiaApp`'s `withApp` hook.

`provideTuyau` creates a fresh context for each server render, while `tuyauContext()` is available for apps that manage the context themselves.

5. **Separate Svelte type-checking**

`@inertiajs/svelte` uses the `svelte` export condition, which the package's normal NodeNext TypeScript setup can't resolve correctly.

For that reason, the Svelte client is excluded from the root `tsconfig.json` and checked separately with `svelte-check` using `tests/types/svelte/tsconfig.json`.

`npm run typecheck` runs both type-checking setups.

The Svelte declarations are generated with `svelte2tsx`'s `emitDts` using the same tsconfig.

6. **`resolvePageComponent` and layouts**

The existing `layout` handling works differently for React/Vue and Svelte.

React/Vue read the layout from the component, while Svelte gets it from the module (`{ default, layout? }`). Svelte also has its own `createInertiaApp` layout option and supports overriding it from a `<script module>` block.

The helper's JSDoc documents this difference.

### Testing

The test runner now uses `--conditions=svelte` together with `tests/support/svelte_loader.mjs` to compile `.svelte` files during tests.

The tests cover:

* `Link` and `Form` route handling
* params, href/action and method overrides
* passing the Tuyau client through `withApp`
* `provideTuyau` and `tuyauContext` sharing the same context
* route-based prop types
* instant-visit page props
* `make:page --svelte`
* `indexPages({ framework: 'svelte' })`

Locally, these are passing:

* `npm run lint`
* `npm run typecheck`
* `npm test`

The main things I'd especially like feedback on are the uncompiled `.svelte` wrappers and the separate Svelte type-checking setup, since those are the parts that affect the build/CI setup.

### 📝 Checklist

* [x] I have linked an issue or discussion.
* [ ] I have updated the documentation accordingly.

Docs for Inertia live in `adonisjs/docs`, so they're not included in this PR. I'll open a separate documentation PR covering the Svelte adapter and `make:page --svelte` once the approach here is settled.
